### PR TITLE
refactor: unify the disk experiment flag name and add value judgment

### DIFF
--- a/exec/os/bin/burnio.go
+++ b/exec/os/bin/burnio.go
@@ -11,11 +11,15 @@ import (
 	"github.com/chaosblade-io/chaosblade/util"
 )
 
-var burnIODevice, burnIOSize, burnIOCount string
+var burnIOMountPoint, burnIOFileSystem, burnIOSize, burnIOCount string
 var burnIORead, burnIOWrite, burnIOStart, burnIOStop, burnIONohup bool
 
 func main() {
-	flag.StringVar(&burnIODevice, "device", "", "disk device")
+	// Filesystem      Size  Used Avail Use% Mounted on
+	///dev/vda1        40G  9.5G   28G  26% /
+	//  mount-point value is /, file-system value is /dev/vda1
+	flag.StringVar(&burnIOMountPoint, "mount-point", "", "mount point of disk")
+	flag.StringVar(&burnIOFileSystem, "file-system", "", "file system of disk")
 	flag.StringVar(&burnIOSize, "size", "", "block size")
 	flag.StringVar(&burnIOCount, "count", "", "block count")
 	flag.BoolVar(&burnIOWrite, "write", false, "write io")
@@ -27,16 +31,16 @@ func main() {
 	flag.Parse()
 
 	if burnIOStart {
-		device, err := getFileSystem(burnIODevice)
-		if err != nil || device == "" {
-			printErrAndExit(fmt.Sprintf("cannot find mount device, %s", burnIODevice))
+		fileSystem, err := getFileSystem(burnIOMountPoint)
+		if err != nil || fileSystem == "" {
+			printErrAndExit(fmt.Sprintf("cannot find mount point, %s", burnIOMountPoint))
 		}
-		startBurnIO(device, burnIOSize, burnIOCount, burnIORead, burnIOWrite)
+		startBurnIO(fileSystem, burnIOSize, burnIOCount, burnIORead, burnIOWrite)
 	} else if burnIOStop {
 		stopBurnIO()
 	} else if burnIONohup {
 		if burnIORead {
-			go burnRead(burnIODevice, burnIOSize, burnIOCount)
+			go burnRead(burnIOFileSystem, burnIOSize, burnIOCount)
 		}
 		if burnIOWrite {
 			go burnWrite(burnIOSize, burnIOCount)
@@ -52,12 +56,12 @@ var logFile = "/tmp/chaos_burnio.log"
 var burnIOBin = "chaos_burnio"
 
 // start burn io
-func startBurnIO(device, size, count string, read, write bool) {
+func startBurnIO(fileSystem, size, count string, read, write bool) {
 	channel := exec.NewLocalChannel()
 	ctx := context.Background()
 	response := channel.Run(ctx, "nohup",
-		fmt.Sprintf(`%s --device %s --size %s --count %s --read=%t --write=%t --nohup=true > %s 2>&1 &`,
-			path.Join(util.GetProgramPath(), burnIOBin), device, size, count, read, write, logFile))
+		fmt.Sprintf(`%s --file-system %s --size %s --count %s --read=%t --write=%t --nohup=true > %s 2>&1 &`,
+			path.Join(util.GetProgramPath(), burnIOBin), fileSystem, size, count, read, write, logFile))
 	if !response.Success {
 		stopBurnIO()
 		printErrAndExit(response.Err)
@@ -104,9 +108,10 @@ func burnWrite(size, count string) {
 }
 
 // read burn
-func burnRead(device, size, count string) {
+func burnRead(fileSystem, size, count string) {
 	for {
-		args := fmt.Sprintf(`if=%s of=/dev/null bs=%sM count=%s iflag=dsync,direct,fullblock`, device, size, count)
+		// "if" arg in dd command is file system value, but "of" arg value is related to mount point
+		args := fmt.Sprintf(`if=%s of=/dev/null bs=%sM count=%s iflag=dsync,direct,fullblock`, fileSystem, size, count)
 		response := exec.NewLocalChannel().Run(context.Background(), "dd", args)
 		if !response.Success {
 			printAndExitWithErrPrefix(response.Err)
@@ -115,8 +120,8 @@ func burnRead(device, size, count string) {
 }
 
 // get fileSystem by mount point
-func getFileSystem(mountOn string) (string, error) {
-	response := exec.NewLocalChannel().Run(context.Background(), "mount", fmt.Sprintf(` | grep "on %s " | awk '{print $1}'`, mountOn))
+func getFileSystem(mountPoint string) (string, error) {
+	response := exec.NewLocalChannel().Run(context.Background(), "mount", fmt.Sprintf(` | grep "on %s " | awk '{print $1}'`, mountPoint))
 	if response.Success {
 		fileSystem := response.Result.(string)
 		return strings.TrimSpace(fileSystem), nil

--- a/exec/os/bin/filldisk.go
+++ b/exec/os/bin/filldisk.go
@@ -6,14 +6,16 @@ import (
 	"github.com/chaosblade-io/chaosblade/exec"
 	"flag"
 	"context"
+	"github.com/chaosblade-io/chaosblade/util"
+	"path"
 )
 
 var fillDataFile = "chaos_filldisk.log.dat"
-var fillDiskDevice, fillDiskSize string
+var fillDiskMountPoint, fillDiskSize string
 var fillDiskStart, fillDiskStop bool
 
 func main() {
-	flag.StringVar(&fillDiskDevice, "device", "", "mount device")
+	flag.StringVar(&fillDiskMountPoint, "mount-point", "", "mount point of disk")
 	flag.StringVar(&fillDiskSize, "size", "", "fill size")
 	flag.BoolVar(&fillDiskStart, "start", false, "start fill or not")
 	flag.BoolVar(&fillDiskStop, "stop", false, "stop fill or not")
@@ -24,44 +26,45 @@ func main() {
 		printErrAndExit("must specify start or stop operation")
 	}
 	if fillDiskStart {
-		startFill(fillDiskDevice, fillDiskSize)
+		startFill(fillDiskMountPoint, fillDiskSize)
 	} else if fillDiskStop {
-		stopFill(fillDiskDevice)
+		stopFill(fillDiskMountPoint)
 	} else {
 		printErrAndExit("less --start or --stop flag")
 	}
 }
 
-func startFill(device, size string) {
+func startFill(mountPoint, size string) {
 	channel := exec.NewLocalChannel()
 	ctx := context.Background()
-	response := channel.Run(ctx, "df", fmt.Sprintf(`-h %s | grep -v 'Mounted on' | awk '{print $NF}'`, device))
+	response := channel.Run(ctx, "df", fmt.Sprintf(`-h %s | grep -v 'Mounted on' | awk '{print $NF}'`, mountPoint))
 	if !response.Success {
 		printErrAndExit(response.Err)
 	}
 	path := strings.TrimSpace(response.Result.(string))
 	if len(path) == 0 {
-		printErrAndExit("cannot find disk device")
+		printErrAndExit("cannot find disk mount point")
 	}
 	if path[len(path)-1:] != "/" {
 		path = path + "/"
 	}
+	// "if" arg in dd command is file system value, but "of" arg value is related to mount point
 	dataFile := fmt.Sprintf("%s%s", path, fillDataFile)
 	response = channel.Run(ctx, "dd", fmt.Sprintf(`if=/dev/zero of=%s bs=1b count=1 iflag=fullblock`, dataFile))
 	if !response.Success {
-		stopFill(device)
+		stopFill(mountPoint)
 		printErrAndExit(response.Err)
 	}
 	response = channel.Run(ctx, "nohup",
 		fmt.Sprintf(`dd if=/dev/zero of=%s bs=1M count=%s iflag=fullblock >/dev/null 2>&1 &`, dataFile, size))
 	if !response.Success {
-		stopFill(device)
+		stopFill(mountPoint)
 		printErrAndExit(response.Err)
 	}
 	printOutputAndExit(response.Result.(string))
 }
 
-func stopFill(device string) {
+func stopFill(mountPoint string) {
 	channel := exec.NewLocalChannel()
 	ctx := context.Background()
 	pids, _ := exec.GetPidsByProcessName(fillDataFile, ctx)
@@ -69,5 +72,11 @@ func stopFill(device string) {
 	if pids != nil || len(pids) >= 0 {
 		channel.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
 	}
-	channel.Run(ctx, "rm", fmt.Sprintf(`-rf %s%s`, device, fillDataFile))
+	fileName := path.Join(mountPoint, fillDataFile)
+	if util.IsExist(fileName) {
+		response := channel.Run(ctx, "rm", fmt.Sprintf(`-rf %s`, fileName))
+		if !response.Success {
+			printErrAndExit(response.Err)
+		}
+	}
 }

--- a/exec/os/disk.go
+++ b/exec/os/disk.go
@@ -34,7 +34,7 @@ func (*DiskCommandSpec) Flags() []exec.ExpFlagSpec {
 	return []exec.ExpFlagSpec{
 		&exec.ExpFlag{
 			Name: "mount-point",
-			Desc: "the disk device mounted point",
+			Desc: "the disk mount point",
 		},
 	}
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,19 @@
+package util
+
+import "testing"
+
+func TestIsExist_ForMountPoint(t *testing.T) {
+	tests := []struct {
+		device string
+		want   bool
+	}{
+		{"/", true},
+		{"/dev", true},
+		{"devfs", false},
+	}
+	for _, tt := range tests {
+		if got := IsExist(tt.device); got != tt.want {
+			t.Errorf("unexpected result: %t, expected: %t", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
1. In order to better understand the meaning of the `--mount-point` flag, the parameter name in code was modified.

2. Add `--mount-point` value check to fix the issue #19 