### PR TITLE
bugfix: fix destroy experiment is delete k8s pod error

### DIFF
--- a/exec/kubernetes/spec_delete.go
+++ b/exec/kubernetes/spec_delete.go
@@ -73,6 +73,10 @@ func (e *deleteExecutor) Exec(uid string, ctx context.Context, model *exec.ExpMo
 	namespace := model.ActionFlags["namespace"]
 	podName := model.ActionFlags["pod"]
 	containerId := model.ActionFlags["container"]
+	// if invoke destroy, return success directly
+	if _, ok := exec.IsDestroy(ctx); ok {
+		return transport.ReturnSuccess(uid)
+	}
 	if containerId != "" {
 		return e.deleteContainer(containerId, podName, namespace, kubeconfig)
 	}


### PR DESCRIPTION
When invoking destroy command for k8s delete experiment, blade will return success directly.

fix #29 