### PR TITLE
bugfix: fix the java bin path when preparing

### DIFF
--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -91,7 +91,7 @@ func attach(pid, port string, ctx context.Context) *transport.Response {
 		sandboxHome, token, "127.0.0.1", port, DefaultNamespace)
 	javaArgs := fmt.Sprintf(`%s -jar %s/sandbox-core.jar %s "%s/sandbox-agent.jar" "%s"`,
 		jvmOpts, sandboxLibPath, pid, sandboxLibPath, sandboxAttachArgs)
-	response = channel.Run(ctx, "java", javaArgs)
+	response = channel.Run(ctx, path.Join(javaHome, "bin/java"), javaArgs)
 	if !response.Success {
 		return response
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Does this pull request fix one issue?
see #77 details
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Get `java` command path from JAVA_HOME env.
