### PR TITLE
feature: add query for the hit counts of java experiments

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -39,6 +39,7 @@ func main() {
 	baseCmd.AddCommand(queryCommand)
 	queryCommand.AddCommand(&QueryDiskCommand{})
 	queryCommand.AddCommand(&QueryNetworkCommand{})
+	queryCommand.AddCommand(&QueryJvmCommand{})
 
 	if err := cli.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())

--- a/cli/query_jvm.go
+++ b/cli/query_jvm.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"fmt"
+	"github.com/chaosblade-io/chaosblade/exec/jvm"
+)
+
+type QueryJvmCommand struct {
+	baseCommand
+}
+
+func (qjc *QueryJvmCommand) Init() {
+	qjc.command = &cobra.Command{
+		Use:   "jvm <UID>",
+		Short: "Query hit counts of the specify experiment",
+		Long:  "Query hit counts of the specify experiment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return qjc.queryJvmExpStatus(cmd, args[0])
+		},
+		Example: qjc.queryJvmExample(),
+	}
+}
+
+func (qjc *QueryJvmCommand) queryJvmExample() string {
+	return `blade query jvm 29c3f9dab4abbc79`
+}
+
+// queryJvmExpStatus by uid
+func (qjc *QueryJvmCommand) queryJvmExpStatus(command *cobra.Command, arg string) error {
+	response := jvm.NewExecutor().QueryStatus(arg)
+	if response.Success {
+		command.Println(response.Print())
+	} else {
+		return fmt.Errorf(response.Error())
+	}
+	return nil
+}

--- a/exec/jvm/executor.go
+++ b/exec/jvm/executor.go
@@ -4,15 +4,14 @@ import (
 	"github.com/chaosblade-io/chaosblade/transport"
 	"context"
 	"fmt"
-	"strings"
 	"github.com/chaosblade-io/chaosblade/exec"
 	"github.com/chaosblade-io/chaosblade/data"
 	"encoding/json"
 	"github.com/chaosblade-io/chaosblade/util"
+	"strings"
 )
 
 const DefaultUri = "sandbox/default/module/http/chaosblade"
-const Sandbox404 = "Error 404 Not Found"
 
 // Executor for jvm experiment
 type Executor struct {
@@ -37,7 +36,7 @@ func (e *Executor) SetChannel(channel exec.Channel) {
 
 func (e *Executor) Exec(uid string, ctx context.Context, model *exec.ExpModel) *transport.Response {
 	var url_ string
-	port, err := e.getPortFromDB(model)
+	port, err := e.getPortFromDB(model.ActionFlags["process"])
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.ServerError], "cannot get port from local")
 	}
@@ -46,11 +45,11 @@ func (e *Executor) Exec(uid string, ctx context.Context, model *exec.ExpModel) *
 	} else {
 		url_ = e.createUrl(port, uid, model)
 	}
-	result, err := util.Curl(url_)
+	result, err, code := util.Curl(url_)
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
 	}
-	if strings.Contains(result, Sandbox404) {
+	if code == 404 {
 		return transport.ReturnFail(transport.Code[transport.JavaAgentCmdError], "please invoke attach command first")
 	}
 	var resp transport.Response
@@ -80,16 +79,66 @@ func (e *Executor) destroyUrl(port, uid string) string {
 	return url
 }
 
+func (e *Executor) QueryStatus(uid string) *transport.Response {
+	experimentModel, err := db.QueryExperimentModelByUid(uid)
+	if err != nil {
+		return transport.ReturnFail(transport.Code[transport.DatabaseError],
+			fmt.Sprintf("query experiment error, %s", err.Error()))
+	}
+	if experimentModel == nil {
+		return transport.ReturnFail(transport.Code[transport.DataNotFound], "the experiment record not found")
+	}
+	// get process flag
+	process := getProcessFlagFromExpRecord(experimentModel)
+	port, err := e.getPortFromDB(process)
+	if err != nil {
+		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
+	}
+	url := e.statusUrl(port, uid)
+	result, err, code := util.Curl(url)
+	if err != nil {
+		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
+	}
+	if code == 404 {
+		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], "the command not support")
+	}
+	if code != 200 {
+		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], result)
+	}
+	var resp transport.Response
+	json.Unmarshal([]byte(result), &resp)
+	return &resp
+}
+
+func (e *Executor) statusUrl(port, uid string) string {
+	return fmt.Sprintf("http://%s:%s/%s/status?suid=%s", "127.0.0.1", port, e.Uri, uid)
+}
+
 var db = data.GetSource()
 
-func (e *Executor) getPortFromDB(model *exec.ExpModel) (string, error) {
-	processName := model.ActionFlags["process"]
-	record, err := db.QueryRunningPreByTypeAndProcess("jvm", processName)
+func (e *Executor) getPortFromDB(process string) (string, error) {
+	record, err := db.QueryRunningPreByTypeAndProcess("jvm", process)
 	if err != nil {
 		return "", err
 	}
 	if record == nil {
-		return "", fmt.Errorf("port not found for %s process, please execute prepare command firstly", processName)
+		return "", fmt.Errorf("port not found for %s process, please execute prepare command firstly", process)
 	}
 	return record.Port, nil
+}
+
+func getProcessFlagFromExpRecord(model *data.ExperimentModel) string {
+	flagValue := model.Flag
+	fields := strings.Fields(flagValue)
+	for idx, value := range fields {
+		if strings.HasPrefix(value, "--process") || strings.HasPrefix(value, "-process") {
+			// contains process flag, predicate equal symbol next
+			eqlIdx := strings.Index(value, "=")
+			if eqlIdx > 0 {
+				return value[eqlIdx+1:]
+			}
+			return fields[idx+1]
+		}
+	}
+	return ""
 }

--- a/util/util.go
+++ b/util/util.go
@@ -86,7 +86,7 @@ func GetUserHome() string {
 }
 
 // Curl url
-func Curl(url string) (string, error) {
+func Curl(url string) (string, error, int) {
 	trans := http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return net.DialTimeout(network, addr, 10*time.Second)
@@ -97,12 +97,12 @@ func Curl(url string) (string, error) {
 	}
 	resp, err := client.Get(url)
 	if err != nil {
-		return "", err
+		return "", err, 0
 	}
 	defer resp.Body.Close()
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", err
+		return "", err, resp.StatusCode
 	}
-	return string(bytes), nil
+	return string(bytes), nil, resp.StatusCode
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Assert whether the java experiment is in effect and get the hit counts.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Feature #100 

### Describe how you did it
1. Add `jvm` subcommand in `query` command.
2. Add `status` handler in chaos java agent.

### Describe how to verify it
Create a java experiment and execute `blade query jvm UID` command. Compare returned results and triggered times.

### Special notes for reviews
Modified the `util.Curl` function, added response code return value.