### PR TITLE
docs: fix typo errors in chaos_experiment_model_CN.md and logic_flow_…

### DIFF
--- a/docs/chaos_experiment_model_CN.md
+++ b/docs/chaos_experiment_model_CN.md
@@ -52,7 +52,7 @@ blade create dubbo delay --time 3000 --consumer --service com.example.HelloServi
 
 ## chaosblade 模型结构图
 
-为了有个更加直观的认识，我们先通过一下的模型结构图来大致看一下模型之间的关系。核心接口模型是：ExpModelCommandSpec，由它引申出来的是ExpActionCommandSpec和ExpFlagSpec这两个接口。其中，ExpModelCommandSpec已有的具体实现有：cpu、network、disk等；ExpActionCommandSpec则是如cpu下的fullload之类的；ExpFlagSpec是各类自定义参数，比如--timeout。更加详细的模型定义说明请见后续小节。
+为了有个更加直观的认识，我们先通过以下的模型结构图来大致看一下模型之间的关系。核心接口模型是：ExpModelCommandSpec，由它引申出来的是ExpActionCommandSpec和ExpFlagSpec这两个接口。其中，ExpModelCommandSpec已有的具体实现有：cpu、network、disk等；ExpActionCommandSpec则是如cpu下的fullload之类的；ExpFlagSpec是各类自定义参数，比如--timeout。更加详细的模型定义说明请见后续小节。
 
 ![模型简图](https://user-images.githubusercontent.com/3992234/56200214-ecfb3300-6070-11e9-9c33-a318eb305bd9.png)
 
@@ -128,7 +128,7 @@ func (*NetworkCommandSpec) Actions() []exec.ExpActionCommandSpec {
 }
 ```
 
-network target 定义了 `DelayActionSpec`、`DropActionSpec`、`DnsActionSpec`、`LossActionSpec` 四中混沌实验场景，其中 `DelayActionSpec` 定义如下：
+network target 定义了 `DelayActionSpec`、`DropActionSpec`、`DnsActionSpec`、`LossActionSpec` 四种混沌实验场景，其中 `DelayActionSpec` 定义如下：
 
 ```go
 type DelayActionSpec struct {

--- a/docs/logic_flow_Introduction_CN.md
+++ b/docs/logic_flow_Introduction_CN.md
@@ -24,7 +24,7 @@ blade create help
 blade create cpu help
 ```
 
-在你输入blade之后不知所措的时候，一路help下去会有惊喜不断，感觉大神提供的彩蛋。
+在你输入blade之后不知所措的时候，一路help下去会有惊喜不断，感谢大神提供的彩蛋。
 
 ### 各类create子命令
 


### PR DESCRIPTION
### Describe what this PR does / why we need it
Fix some typo errors in chaos_experiment_model_CN.md and logic_flow_Introduction_CN.md

