### PR TITLE
bugfix: fix java agent attach status error caused by revoke repeatly

### DIFF
--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -33,7 +33,7 @@ func Attach(processName string, port string) *transport.Response {
 	}
 	pid := pids[0]
 	// refresh
-	response := refresh(pid, port, ctx)
+	response := attach(pid, port, ctx)
 	if !response.Success {
 		return response
 	}
@@ -67,20 +67,7 @@ func active(port string) *transport.Response {
 	return transport.ReturnSuccess("success")
 }
 
-// execute bash bin/sandbox.sh -p $pid -P $2 -R 2>&1
-func refresh(pid, port string, ctx context.Context) *transport.Response {
-	response := attach(pid, port, ctx)
-	if !response.Success {
-		return response
-	}
-	url := getSandboxUrl(port, "sandbox-module-mgr/reset", "")
-	_, err := util.Curl(url)
-	if err != nil {
-		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
-	}
-	return transport.ReturnSuccess("refresh success")
-}
-
+// attach java agent to application process
 func attach(pid, port string, ctx context.Context) *transport.Response {
 	javaHome := os.Getenv("JAVA_HOME")
 	if javaHome == "" {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Fix java agent attach status error caused by revoke repeatly

### Does this pull request fix one issue?
see this #120 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
check prepare record status, if it's already "Revoked", db record will not be changed to the wrong status and print success instead of fail.

### Describe how to verify it
see #120 

