### PR TITLE
feature: add --pid for jvm preparation

### DIFF
--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -160,7 +160,8 @@ func (*MockSource) QueryPreparationByUid(uid string) (*data.PreparationRecord, e
 	return &data.PreparationRecord{}, nil
 }
 
-func (*MockSource) QueryRunningPreByTypeAndProcess(programType string, process string) (*data.PreparationRecord, error) {
+func (*MockSource) QueryRunningPreByTypeAndProcess(programType string, processName string,
+	processId string) (*data.PreparationRecord, error) {
 	return &data.PreparationRecord{}, nil
 }
 

--- a/cli/prepare.go
+++ b/cli/prepare.go
@@ -42,7 +42,7 @@ func (pc *PrepareCommand) prepareExample() string {
 }
 
 // insertPrepareRecord
-func insertPrepareRecord(prepareType string, flags ...string) (*data.PreparationRecord, error) {
+func insertPrepareRecord(prepareType string, processName, port, processId string) (*data.PreparationRecord, error) {
 	uid, err := util.GenerateUid()
 	if err != nil {
 		return nil, err
@@ -50,14 +50,13 @@ func insertPrepareRecord(prepareType string, flags ...string) (*data.Preparation
 	record := &data.PreparationRecord{
 		Uid:         uid,
 		ProgramType: prepareType,
-		Process:     flags[0],
+		Process:     processName,
+		Port:        port,
+		Pid:         processId,
 		Status:      "Created",
 		Error:       "",
 		CreateTime:  time.Now().Format(time.RFC3339Nano),
 		UpdateTime:  time.Now().Format(time.RFC3339Nano),
-	}
-	if len(flags) > 1 {
-		record.Port = flags[1]
 	}
 	err = GetDS().InsertPreparationRecord(record)
 	if err != nil {

--- a/cli/prepare_cplus.go
+++ b/cli/prepare_cplus.go
@@ -40,13 +40,13 @@ func (pc *PrepareCPlusCommand) prepareExample() string {
 
 func (pc *PrepareCPlusCommand) prepareCPlus() error {
 	portStr := strconv.Itoa(pc.port)
-	record, err := GetDS().QueryRunningPreByTypeAndProcess(PrepareCPlusType, portStr)
+	record, err := GetDS().QueryRunningPreByTypeAndProcess(PrepareCPlusType, portStr, "")
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.DatabaseError],
 			fmt.Sprintf("query cplus agent server port record err, %s", err.Error()))
 	}
 	if record == nil || record.Status != "Running" {
-		record, err = insertPrepareRecord(PrepareCPlusType, portStr, portStr)
+		record, err = insertPrepareRecord(PrepareCPlusType, portStr, portStr, "")
 		if err != nil {
 			return transport.ReturnFail(transport.Code[transport.DatabaseError],
 				fmt.Sprintf("insert prepare record err, %s", err.Error()))

--- a/cli/prepare_test.go
+++ b/cli/prepare_test.go
@@ -21,7 +21,7 @@ func TestPrepareJvmCommand_insertPrepareRecord(t *testing.T) {
 	}{
 		{
 			input{
-				PrepareJvmType, []string{"project.name", "8703"},
+				PrepareJvmType, []string{"project.name", "8703", ""},
 			},
 			expect{
 				&data.PreparationRecord{
@@ -34,7 +34,7 @@ func TestPrepareJvmCommand_insertPrepareRecord(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := insertPrepareRecord(tt.input.prepareType, tt.input.flags...)
+		got, err := insertPrepareRecord(tt.input.prepareType, tt.input.flags[0], tt.input.flags[1], tt.input.flags[2])
 		if (err != nil) != tt.expect.err {
 			t.Errorf("unexpected result: %t, expected: %t", err != nil, tt.expect.err)
 		}

--- a/data/source.go
+++ b/data/source.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"sync"
 	_ "github.com/mattn/go-sqlite3"
+	"fmt"
 )
 
 const dataFile = "chaosblade.dat"
@@ -57,4 +58,24 @@ func (s *Source) Close() {
 	if s.DB != nil {
 		s.DB.Close()
 	}
+}
+
+// GetUserVersion returns the user_version value
+func (s *Source) GetUserVersion() (int, error) {
+	userVerRows, err := s.DB.Query("PRAGMA user_version")
+	if err != nil {
+		return 0, err
+	}
+	defer userVerRows.Close()
+	var userVersion int
+	for userVerRows.Next() {
+		userVerRows.Scan(&userVersion)
+	}
+	return userVersion, nil
+}
+
+// UpdateUserVersion to the latest
+func (s *Source) UpdateUserVersion(version int) error {
+	_, err := s.DB.Exec(fmt.Sprintf("PRAGMA user_version=%d", version))
+	return err
 }

--- a/exec/cplus/executor.go
+++ b/exec/cplus/executor.go
@@ -77,7 +77,7 @@ var db = data.GetSource()
 
 func (e *Executor) getPortFromDB(model *exec.ExpModel) (string, error) {
 	port := model.ActionFlags["port"]
-	record, err := db.QueryRunningPreByTypeAndProcess("cplus", port)
+	record, err := db.QueryRunningPreByTypeAndProcess("cplus", port, "")
 	if err != nil {
 		return "", err
 	}

--- a/exec/jvm/executor.go
+++ b/exec/jvm/executor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-  
+
 	"github.com/chaosblade-io/chaosblade/data"
 	"github.com/chaosblade-io/chaosblade/exec"
 	"github.com/chaosblade-io/chaosblade/transport"
@@ -38,9 +38,9 @@ func (e *Executor) SetChannel(channel exec.Channel) {
 
 func (e *Executor) Exec(uid string, ctx context.Context, model *exec.ExpModel) *transport.Response {
 	var url_ string
-	port, err := e.getPortFromDB(model.ActionFlags["process"])
+	port, err := e.getPortFromDB(model.ActionFlags["process"], "")
 	if err != nil {
-		return transport.ReturnFail(transport.Code[transport.ServerError], "cannot get port from local")
+		return transport.ReturnFail(transport.Code[transport.ServerError], "cannot get port from local, please execute prepare command first")
 	}
 	if _, ok := exec.IsDestroy(ctx); ok {
 		url_ = e.destroyUrl(port, uid)
@@ -52,7 +52,7 @@ func (e *Executor) Exec(uid string, ctx context.Context, model *exec.ExpModel) *
 		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
 	}
 	if code == 404 {
-		return transport.ReturnFail(transport.Code[transport.JavaAgentCmdError], "please invoke attach command first")
+		return transport.ReturnFail(transport.Code[transport.JavaAgentCmdError], "please execute prepare command first")
 	}
 	var resp transport.Response
 	json.Unmarshal([]byte(result), &resp)
@@ -92,7 +92,7 @@ func (e *Executor) QueryStatus(uid string) *transport.Response {
 	}
 	// get process flag
 	process := getProcessFlagFromExpRecord(experimentModel)
-	port, err := e.getPortFromDB(process)
+	port, err := e.getPortFromDB(process, "")
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.SandboxInvokeError], err.Error())
 	}
@@ -118,13 +118,20 @@ func (e *Executor) statusUrl(port, uid string) string {
 
 var db = data.GetSource()
 
-func (e *Executor) getPortFromDB(process string) (string, error) {
-	record, err := db.QueryRunningPreByTypeAndProcess("jvm", process)
+func (e *Executor) getPortFromDB(processName, processId string) (string, error) {
+	if processName != "" || processId != "" {
+		pid, response := CheckFlagValues(processName, processId)
+		if !response.Success {
+			return "", fmt.Errorf(response.Err)
+		}
+		processId = pid
+	}
+	record, err := db.QueryRunningPreByTypeAndProcess("jvm", processName, processId)
 	if err != nil {
 		return "", err
 	}
 	if record == nil {
-		return "", fmt.Errorf("port not found for %s process, please execute prepare command firstly", process)
+		return "", fmt.Errorf("port not found for %s process, please execute prepare command firstly", processName)
 	}
 	return record.Port, nil
 }
@@ -143,4 +150,59 @@ func getProcessFlagFromExpRecord(model *data.ExperimentModel) string {
 		}
 	}
 	return ""
+}
+
+// checkFlagValues
+// query pre-record from sqlite by process name or process id
+// 1. The process and pid are not empty, then the process is used to find the process. If the process id and the found process are not found, the error is returned.
+// 2. Process is empty, pid is not empty, then determine if the pid process exists
+// 3. Process is not empty, pid is empty, then it is judged whether the process exists, there is no error, and the process id is assigned to pid.
+// 4. Process and pid are both empty, then an error is returned.
+func CheckFlagValues(processName, processId string) (string, *transport.Response) {
+	if processName == "" {
+		exists, err := exec.ProcessExists(processId)
+		if err != nil {
+			return processId, transport.ReturnFail(transport.Code[transport.GetProcessError],
+				fmt.Sprintf("the %s process id doesn't exist, %s", processId, err.Error()))
+		}
+		if !exists {
+			return processId, transport.ReturnFail(transport.Code[transport.IllegalParameters],
+				fmt.Sprintf("the %s process id doesn't exist.", processId))
+		}
+	}
+	if processName != "" {
+		ctx := context.WithValue(context.Background(), exec.ProcessKey, "java")
+		pids, err := exec.GetPidsByProcessName(processName, ctx)
+		if err != nil {
+			return processId, transport.ReturnFail(transport.Code[transport.GetProcessError], err.Error())
+		}
+		if pids == nil || len(pids) == 0 {
+			return processId, transport.ReturnFail(transport.Code[transport.GetProcessError], "process not found")
+		}
+		if len(pids) == 1 {
+			if processId == "" {
+				processId = pids[0]
+			} else if processId != pids[0] {
+				return processId, transport.ReturnFail(transport.Code[transport.IllegalParameters],
+					fmt.Sprintf("get process id by process name is %s, not equal the value of pid flag", pids[0]))
+			}
+		} else {
+			if processId == "" {
+				return processId, transport.ReturnFail(transport.Code[transport.GetProcessError], "too many process")
+			} else {
+				var contains bool
+				for _, p := range pids {
+					if p == processId {
+						contains = true
+						break
+					}
+				}
+				if !contains {
+					return processId, transport.ReturnFail(transport.Code[transport.IllegalParameters],
+						"the process ids got by process name does not contain the pid value")
+				}
+			}
+		}
+	}
+	return processId, transport.ReturnSuccess("success")
 }

--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -19,23 +19,9 @@ const DefaultNamespace = "default"
 
 var sandboxTokenFile = path.Join(util.GetUserHome(), ".sandbox.token")
 
-func Attach(processName string, port string, javaHome string) *transport.Response {
-	// get process pid
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, exec.ProcessKey, "java")
-	pids, err := exec.GetPidsByProcessName(processName, ctx)
-	if err != nil {
-		return transport.ReturnFail(transport.Code[transport.GetProcessError], err.Error())
-	}
-	if pids == nil || len(pids) == 0 {
-		return transport.ReturnFail(transport.Code[transport.GetProcessError], "process not found")
-	}
-	if len(pids) != 1 {
-		return transport.ReturnFail(transport.Code[transport.GetProcessError], "too many process")
-	}
-	pid := pids[0]
+func Attach(port string, javaHome string, pid string) *transport.Response {
 	// refresh
-	response := attach(pid, port, ctx, javaHome)
+	response := attach(pid, port, context.TODO(), javaHome)
 	if !response.Success {
 		return response
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See #132 for the detail.

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add pid column in chaosblade sqlite database. Identify database version by `PRAGMA user_version` and alter table if the target table version is old.
2. Add pid flag in preparation of jvm command.
3. Check the process by process name or pid value when executing jvm preparation. 
4. Record the pid value into sqlite.
5. Add pid flag support in chaosblade-exec-jvm project.

### Describe how to verify it
The process id of tomcat is 45399.
```
blade p jvm --process tomcat
{"code":200,"success":true,"result":"3abea82447412dc8"}
```
Use --pid argument, the blade will return the same uid:
```
blade p jvm --pid 45399
{"code":200,"success":true,"result":"3abea82447412dc8"}
```
### Special notes for reviews
1. The process and pid are not empty, then the process is used to find the process. If the process id and the found process are not found, the error is returned.
2. Process is empty, pid is not empty, then determine if the pid process exists
3. Process is not empty, pid is empty, then it is judged whether the process exists, there is no error, and the process id is assigned to pid.
4. Process and pid are both empty, then an error is returned.
