### PR TITLE
burnCpuStop return err fixed

### DIFF
--- a/exec/os/bin/burncpu/burncpu_test.go
+++ b/exec/os/bin/burncpu/burncpu_test.go
@@ -53,8 +53,9 @@ func Test_runBurnCpu_failed(t *testing.T) {
 		exitCode = code
 	}
 	var invokeTime int
-	stopBurnCpuFunc = func() {
+	stopBurnCpuFunc = func()(bool,string) {
 		invokeTime++
+		return true, ""
 	}
 
 	channel = &exec.MockLocalChannel{
@@ -86,7 +87,7 @@ func Test_bindBurnCpu(t *testing.T) {
 	bin.ExitFunc = func(code int) {
 		exitCode = code
 	}
-	stopBurnCpuFunc = func() {}
+	stopBurnCpuFunc = func()(bool,string) { return true, ""}
 
 	channel = &exec.MockLocalChannel{
 		Response:        transport.ReturnFail(transport.Code[transport.CommandNotFound], "taskset command not found"),


### PR DESCRIPTION
Signed-off-by: youzhilane <youzhilane01@gmail.com>

### Does this pull request fix one issue?

Fixes #152 

### Describe how you did it

modified the burncpu.go. when kill a pid run into an err then function stopBurnCpu return false and errsmsg.

### Describe how to verify it

```
$ sudo ./blade create cpu fullload --cpu-list=0-1
{"code":200,"success":true,"result":"e19ec23cb07c89ec"}

$ ./blade destroy e19ec23cb07c89ec               
{"code":604,"success":false,"error":"/bin/sh: 1: kill: Operation not permitted\n\n/bin/sh: 1: kill: Operation not permitted\n\n exit status 1 exit status 1"}
```