### PR TITLE
feature: specify Memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,15 @@ build_cli:
 	# build blade cli
 	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_PKG_DIR)/blade ./cli
 
-build_osbin: build_burncpu build_burnio build_killprocess build_stopprocess build_changedns build_delaynetwork build_dropnetwork build_lossnetwork build_filldisk
+build_osbin: build_burncpu build_burnmem build_burnio build_killprocess build_stopprocess build_changedns build_delaynetwork build_dropnetwork build_lossnetwork build_filldisk
 
 # build burn-cpu chaos tools
 build_burncpu: exec/os/bin/burncpu/burncpu.go
 	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_burncpu $<
+
+# build burn-mem chaos tools
+build_burnmem: exec/os/bin/burnmem/burnmem.go
+	$(GO) build $(GO_FLAGS) -o $(BUILD_TARGET_BIN)/chaos_burnmem $<
 
 # build burn-io chaos tools
 build_burnio: exec/os/bin/burnio/burnio.go

--- a/cli/exp.go
+++ b/cli/exp.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/chaosblade-io/chaosblade/exec"
+	"github.com/chaosblade-io/chaosblade/exec/cplus"
 	"github.com/chaosblade-io/chaosblade/exec/docker"
 	"github.com/chaosblade-io/chaosblade/exec/jvm"
 	"github.com/chaosblade-io/chaosblade/exec/kubernetes"
@@ -18,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/chaosblade-io/chaosblade/exec/cplus"
 )
 
 // ExpActionFlags is used to receive experiment action flags
@@ -102,12 +102,14 @@ var ctx_ = context.Background()
 func (ec *expCommand) registerOsExpCommands() []*modelCommand {
 	// register cpu
 	cpu := ec.registerExpCommand(&os.CpuCommandModelSpec{})
+	mem := ec.registerExpCommand(&os.MemCommandModelSpec{})
 	process := ec.registerExpCommand(&os.ProcessCommandModelSpec{})
 	network := ec.registerExpCommand(&os.NetworkCommandSpec{})
 	disk := ec.registerExpCommand(&os.DiskCommandSpec{})
 	script := ec.registerExpCommand(&os.ScriptCommandModelSpec{})
 	return []*modelCommand{
 		cpu,
+		mem,
 		process,
 		network,
 		disk,

--- a/exec/os/bin/burnmem/burnmem.go
+++ b/exec/os/bin/burnmem/burnmem.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chaosblade-io/chaosblade/exec"
+	"github.com/chaosblade-io/chaosblade/exec/os/bin"
+	"github.com/chaosblade-io/chaosblade/transport"
+	"github.com/chaosblade-io/chaosblade/util"
+	"github.com/shirou/gopsutil/mem"
+)
+
+var (
+	burnMemStart, burnMemStop, burnMemNohup bool
+	memPercent                              int
+)
+
+func main() {
+	flag.BoolVar(&burnMemStart, "start", false, "start burn memory")
+	flag.BoolVar(&burnMemStop, "stop", false, "stop burn memory")
+	flag.BoolVar(&burnMemNohup, "nohup", false, "nohup to run burn memory")
+	flag.IntVar(&memPercent, "mem-percent", 0, "percent of burn memory")
+	flag.Parse()
+
+	if burnMemStart {
+		startBurnMem()
+	} else if burnMemStop {
+		if success, errs := stopBurnMem(); !success {
+			bin.PrintErrAndExit(errs)
+		}
+	} else if burnMemNohup {
+		burnMem()
+	} else {
+		bin.PrintAndExitWithErrPrefix("less --start of --stop flag")
+	}
+
+}
+
+var dirName = "burnmem_tmpfs"
+
+var fileName = "file"
+
+var fileCount = 0
+
+func getMem(filePath string) int64 {
+	sum := int64(0)
+	if 0 == fileCount {
+		return sum
+	}
+	fileInfo, err := os.Stat(filePath + strconv.Itoa(fileCount-1))
+	if err != nil {
+		bin.PrintErrAndExit(err.Error())
+	}
+	sum += fileInfo.Size()/1024/1024 + int64(fileCount-1)*128
+	return sum
+}
+
+func burnMem() {
+
+	filePath := path.Join(path.Join(util.GetProgramPath(), dirName), fileName)
+
+	avPercent := 100 - memPercent
+
+	go func() {
+		t := time.NewTicker(3 * time.Second)
+		for {
+			select {
+			case <-t.C:
+				virtualMemory, err := mem.VirtualMemory()
+				if err != nil {
+					bin.PrintErrAndExit(err.Error())
+				}
+
+				// diff := float64(virtualMemory.Available)/float64(virtualMemory.Total) - float64(avPercent)/100.0
+
+				// if diff > -0.001 && diff < 0.001 {
+				// 	continue
+				// }
+
+				memSum := getMem(filePath)
+
+				needMem := (int64(virtualMemory.Available)-int64(virtualMemory.Total)*int64(avPercent)/100)/1024/1024 + memSum
+
+				if needMem <= 0 {
+					for i := 0; i < fileCount; i++ {
+						os.Remove(filePath + strconv.Itoa(i))
+					}
+					fileCount = 0
+				} else {
+					if memSum%128 != 0 {
+						os.Remove(filePath + strconv.Itoa(fileCount-1))
+						memSum -= memSum % 128
+						fileCount--
+					}
+					if needMem/128 > memSum/128 {
+						for i := memSum / 128; i < needMem/128; i++ {
+							nFilePath := filePath + strconv.FormatInt(i, 10)
+							response := channel.Run(context.Background(), "dd", fmt.Sprintf("if=/dev/zero of=%s bs=1M count=%d", nFilePath, 128))
+							if !response.Success {
+								bin.PrintErrAndExit(response.Error())
+							}
+						}
+					} else {
+						for i := needMem / 128; i < memSum/128; i++ {
+							nFilePath := filePath + strconv.FormatInt(i, 10)
+							os.RemoveAll(nFilePath)
+						}
+					}
+					fileCount = int(needMem / 128)
+					if needMem%128 != 0 {
+						nFilePath := filePath + strconv.Itoa(fileCount)
+						response := channel.Run(context.Background(), "dd", fmt.Sprintf("if=/dev/zero of=%s bs=1M count=%d", nFilePath, needMem%128))
+						if !response.Success {
+							bin.PrintErrAndExit(response.Error())
+						}
+						fileCount++
+					}
+				}
+			}
+		}
+	}()
+	select {}
+}
+
+var burnMemBin = "chaos_burnmem"
+
+var channel = exec.NewLocalChannel()
+
+var stopBurnMemFunc = stopBurnMem
+
+var runBurnMemFunc = runBurnMem
+
+func startBurnMem() {
+	ctx := context.Background()
+
+	flPath := path.Join(util.GetProgramPath(), dirName)
+
+	if _, err := os.Stat(flPath); err != nil {
+		err = os.Mkdir(flPath, os.ModePerm)
+		if err != nil {
+			bin.PrintErrAndExit(err.Error())
+		}
+	}
+
+	response := channel.Run(ctx, "mount", fmt.Sprintf("-t tmpfs tmpfs %s -o size=", flPath)+"100%")
+
+	if !response.Success {
+		bin.PrintErrAndExit(response.Error())
+	}
+
+	runBurnMemFunc(ctx, memPercent)
+}
+
+func runBurnMem(ctx context.Context, memPercent int) int {
+	args := fmt.Sprintf(`%s --nohup --mem-percent %d`,
+		path.Join(util.GetProgramPath(), burnMemBin), memPercent)
+
+	args = fmt.Sprintf(`%s > /dev/null 2>&1 &`, args)
+	response := channel.Run(ctx, "nohup", args)
+	if !response.Success {
+		stopBurnMemFunc()
+		bin.PrintErrAndExit(response.Err)
+	}
+	return -1
+}
+
+func stopBurnMem() (success bool, errs string) {
+	ctx := context.WithValue(context.Background(), exec.ProcessKey, "nohup")
+	pids, _ := exec.GetPidsByProcessName(burnMemBin, ctx)
+	var response *transport.Response
+	if pids != nil && len(pids) != 0 {
+		response = channel.Run(ctx, "kill", fmt.Sprintf(`-9 %s`, strings.Join(pids, " ")))
+		if !response.Success {
+			return false, response.Err
+		}
+	}
+
+	dirPath := path.Join(util.GetProgramPath(), dirName)
+
+	if _, err := os.Stat(dirPath); err == nil {
+		response = channel.Run(ctx, "umount", dirPath)
+
+		if !response.Success {
+			bin.PrintErrAndExit(response.Error())
+		}
+
+		err = os.RemoveAll(dirPath)
+		if err != nil {
+			bin.PrintErrAndExit(err.Error())
+		}
+	}
+
+	return true, errs
+}

--- a/exec/os/bin/burnmem/burnmem_test.go
+++ b/exec/os/bin/burnmem/burnmem_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/chaosblade-io/chaosblade/exec"
+	"github.com/chaosblade-io/chaosblade/exec/os/bin"
+	"github.com/chaosblade-io/chaosblade/transport"
+	"github.com/chaosblade-io/chaosblade/util"
+)
+
+func Test_startBurnMem(t *testing.T) {
+
+	var exitCode int
+	bin.ExitFunc = func(code int) {
+		exitCode = code
+	}
+
+	runBurnMemFunc = func(context.Context, int) int {
+		return 1
+	}
+
+	stopBurnMemFunc = func() (bool, string) {
+		return true, ""
+	}
+
+	flPath := path.Join(util.GetProgramPath(), dirName)
+	channel = &exec.MockLocalChannel{
+		Response:        transport.ReturnSuccess("success"),
+		ExpectedCommand: fmt.Sprintf("mount -t tmpfs tmpfs %s -o size=", flPath) + "100%",
+		T:               t,
+	}
+
+	startBurnMem()
+	if exitCode != 0 {
+		t.Errorf("unexpected result %d, expected result: %d", exitCode, 0)
+	}
+
+}
+
+func Test_runBurnMem_failed(t *testing.T) {
+	type args struct {
+		memPercent int
+	}
+	as := &args{
+		memPercent: 50,
+	}
+
+	burnBin := path.Join(util.GetProgramPath(), "chaos_burnmem")
+	var exitCode int
+	bin.ExitFunc = func(code int) {
+		exitCode = code
+	}
+
+	channel = &exec.MockLocalChannel{
+		Response:        transport.ReturnFail(transport.Code[transport.CommandNotFound], "nohup command not found"),
+		ExpectedCommand: fmt.Sprintf(`nohup %s --nohup --mem-percent 50 > /dev/null 2>&1 &`, burnBin),
+		T:               t,
+	}
+
+	stopBurnMemFunc = func() (bool, string) {
+		return true, ""
+	}
+
+	runBurnMem(context.Background(), as.memPercent)
+
+	if exitCode != 1 {
+		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
+	}
+
+}
+
+func Test_stopBurnMem(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{"stop"},
+	}
+	channel = exec.NewLocalChannel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stopBurnMem()
+		})
+	}
+}

--- a/exec/os/mem.go
+++ b/exec/os/mem.go
@@ -1,0 +1,143 @@
+package os
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+
+	"github.com/chaosblade-io/chaosblade/exec"
+	"github.com/chaosblade-io/chaosblade/transport"
+)
+
+type MemCommandModelSpec struct {
+}
+
+func (*MemCommandModelSpec) Name() string {
+	return "mem"
+}
+
+func (*MemCommandModelSpec) ShortDesc() string {
+	return "Mem experiment"
+}
+
+func (*MemCommandModelSpec) LongDesc() string {
+	return "Mem experiment, for example load"
+}
+
+func (*MemCommandModelSpec) Example() string {
+	return "mem load"
+}
+
+func (*MemCommandModelSpec) Actions() []exec.ExpActionCommandSpec {
+	return []exec.ExpActionCommandSpec{
+		&loadActionCommand{},
+	}
+}
+
+func (cms *MemCommandModelSpec) Flags() []exec.ExpFlagSpec {
+	return []exec.ExpFlagSpec{
+		&exec.ExpFlag{
+			Name:     "mem-percent",
+			Desc:     "percent of burn Memory (0-100)",
+			Required: false,
+		},
+	}
+}
+
+func (*MemCommandModelSpec) PreExecutor() exec.PreExecutor {
+	return &memPreExecutor{}
+}
+
+type memPreExecutor struct {
+}
+
+func (*memPreExecutor) PreExec(cmdName, parentCmdName string, flags map[string]string) func(ctx context.Context) (exec.Channel, context.Context, error) {
+	return nil
+}
+
+type loadActionCommand struct {
+}
+
+func (*loadActionCommand) Name() string {
+	return "load"
+}
+
+func (*loadActionCommand) Aliases() []string {
+	return []string{}
+}
+
+func (*loadActionCommand) ShortDesc() string {
+	return "mem load"
+}
+
+func (*loadActionCommand) LongDesc() string {
+	return "mem load"
+}
+
+func (*loadActionCommand) Matchers() []exec.ExpFlagSpec {
+	return []exec.ExpFlagSpec{}
+}
+
+func (*loadActionCommand) Flags() []exec.ExpFlagSpec {
+	return []exec.ExpFlagSpec{}
+}
+
+func (*loadActionCommand) Executor(channel exec.Channel) exec.Executor {
+	return &memExecutor{
+		channel: channel,
+	}
+}
+
+type memExecutor struct {
+	channel exec.Channel
+}
+
+func (ce *memExecutor) Name() string {
+	return "mem"
+}
+
+func (ce *memExecutor) SetChannel(channel exec.Channel) {
+	ce.channel = channel
+}
+
+func (ce *memExecutor) Exec(uid string, ctx context.Context, model *exec.ExpModel) *transport.Response {
+	if ce.channel == nil {
+		return transport.ReturnFail(transport.Code[transport.ServerError], "channel is nil")
+	}
+	if _, ok := exec.IsDestroy(ctx); ok {
+		return ce.stop(ctx)
+	}
+	var memPercent int
+
+	memPercentStr := model.ActionFlags["mem-percent"]
+	if memPercentStr != "" {
+		var err error
+		memPercent, err = strconv.Atoi(memPercentStr)
+		if err != nil {
+			return transport.ReturnFail(transport.Code[transport.IllegalParameters],
+				"--mem-percent value must be a positive integer")
+		}
+		if memPercent > 100 || memPercent < 0 {
+			return transport.ReturnFail(transport.Code[transport.IllegalParameters],
+				"--mem-percent value must be a prositive integer and not bigger than 100")
+		}
+	} else {
+		memPercent = 100
+	}
+
+	return ce.start(ctx, memPercent)
+}
+
+const burnMemBin = "chaos_burnmem"
+
+// start burn mem
+func (ce *memExecutor) start(ctx context.Context, memPercent int) *transport.Response {
+	args := fmt.Sprintf("--start --mem-percent %d", memPercent)
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin), args)
+}
+
+// stop burn mem
+func (ce *memExecutor) stop(ctx context.Context) *transport.Response {
+	return ce.channel.Run(ctx, path.Join(ce.channel.GetScriptPath(), burnMemBin), "--stop")
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
In a Linux system, we can specify Memory usage of a machine by use command : blade c mem load --mem-percent value

### Does this pull request fix one issue?
#161 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Add multiple files using #tmpfs# file system to occupy memory

### Describe how to verify it
```
$ ./blade c mem load --mem-percent 50
{"code":200,"success":true,"result":"4ac2b3ad3f8c30bc"}
$ ./blade d 4ac2b3ad3f8c30bc
{"code":200,"success":true,"result":"command: mem load --debug false --help false --mem-percent 50"}
```
![image](https://user-images.githubusercontent.com/16305150/62942278-89a8c400-be0a-11e9-8365-01d2aa6990fa.png)

