### PR TITLE
fix: Make blade can be start any where.

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"encoding/hex"
 	"time"
-	"path/filepath"
 	"os"
 	"log"
 	"reflect"
@@ -14,6 +13,8 @@ import (
 	"net/http"
 	"io/ioutil"
 	"context"
+	"os/exec"
+	"path/filepath"
 )
 
 var proPath string
@@ -25,12 +26,15 @@ func GetProgramPath() string {
 	if proPath != "" {
 		return proPath
 	}
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	dir, err := exec.LookPath(os.Args[0])
 	if err != nil {
 		log.Fatal("can get the process path")
 	}
-	proPath = dir
-	return dir
+	if p, err := os.Readlink(dir); err == nil {
+		dir = p
+	}
+	proPath = filepath.Dir(dir)
+	return proPath
 }
 
 // GetBinPath


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

make blade can be start any where if you use a relative path.

### Does this pull request fix one issue?

Fixes #48

### Describe how you did it

use exec.LookPath and os.Readlink to get the execution path.

### Describe how to verify it


### Special notes for reviews
