### PR TITLE
Add path flag in disk fill to specify any directory

### DIFF
--- a/exec/os/bin/filldisk/filldisk.go
+++ b/exec/os/bin/filldisk/filldisk.go
@@ -13,11 +13,11 @@ import (
 )
 
 var fillDataFile = "chaos_filldisk.log.dat"
-var fillDiskMountPoint, fillDiskSize string
+var fillDiskSize, fillDiskDirectory string
 var fillDiskStart, fillDiskStop bool
 
 func main() {
-	flag.StringVar(&fillDiskMountPoint, "mount-point", "", "mount point of disk")
+	flag.StringVar(&fillDiskDirectory, "directory", "", "the directory where the disk is populated")
 	flag.StringVar(&fillDiskSize, "size", "", "fill size")
 	flag.BoolVar(&fillDiskStart, "start", false, "start fill or not")
 	flag.BoolVar(&fillDiskStop, "stop", false, "stop fill or not")
@@ -28,9 +28,9 @@ func main() {
 		bin.PrintErrAndExit("must specify start or stop operation")
 	}
 	if fillDiskStart {
-		startFill(fillDiskMountPoint, fillDiskSize)
+		startFill(fillDiskDirectory, fillDiskSize)
 	} else if fillDiskStop {
-		stopFill(fillDiskMountPoint)
+		stopFill(fillDiskDirectory)
 	} else {
 		bin.PrintErrAndExit("less --start or --stop flag")
 	}
@@ -38,18 +38,18 @@ func main() {
 
 var channel = exec.NewLocalChannel()
 
-func startFill(mountPoint, size string) {
+func startFill(directory, size string) {
 	ctx := context.Background()
-	if mountPoint == "" {
-		bin.PrintErrAndExit("mount-point flag is empty")
+	if directory == "" {
+		bin.PrintErrAndExit("--directory flag value is empty")
 	}
-	dataFile := path.Join(mountPoint, fillDataFile)
+	dataFile := path.Join(directory, fillDataFile)
 
 	// Some normal filesystems (ext4, xfs, btrfs and ocfs2) tack quick works
 	if exec.IsCommandAvailable("fallocate") {
 		response := channel.Run(ctx, "fallocate", fmt.Sprintf(`-l %sM %s`, size, dataFile))
 		if !response.Success {
-			stopFill(mountPoint)
+			stopFill(directory)
 			bin.PrintErrAndExit(response.Err)
 		}
 		bin.PrintOutputAndExit(response.Result.(string))
@@ -57,26 +57,26 @@ func startFill(mountPoint, size string) {
 
 	response := channel.Run(ctx, "dd", fmt.Sprintf(`if=/dev/zero of=%s bs=1b count=1 iflag=fullblock`, dataFile))
 	if !response.Success {
-		stopFill(mountPoint)
+		stopFill(directory)
 		bin.PrintErrAndExit(response.Err)
 	}
 	response = channel.Run(ctx, "nohup",
 		fmt.Sprintf(`dd if=/dev/zero of=%s bs=1M count=%s iflag=fullblock >/dev/null 2>&1 &`, dataFile, size))
 	if !response.Success {
-		stopFill(mountPoint)
+		stopFill(directory)
 		bin.PrintErrAndExit(response.Err)
 	}
 	bin.PrintOutputAndExit(response.Result.(string))
 }
 
-func stopFill(mountPoint string) {
+func stopFill(directory string) {
 	ctx := context.Background()
 	pids, _ := exec.GetPidsByProcessName(fillDataFile, ctx)
 
 	if pids != nil || len(pids) >= 0 {
 		channel.Run(ctx, "kill", fmt.Sprintf("-9 %s", strings.Join(pids, " ")))
 	}
-	fileName := path.Join(mountPoint, fillDataFile)
+	fileName := path.Join(directory, fillDataFile)
 	if util.IsExist(fileName) {
 		response := channel.Run(ctx, "rm", fmt.Sprintf(`-rf %s`, fileName))
 		if !response.Success {

--- a/exec/os/disk_fill.go
+++ b/exec/os/disk_fill.go
@@ -22,20 +22,25 @@ func (*FillActionSpec) Aliases() []string {
 }
 
 func (*FillActionSpec) ShortDesc() string {
-	return "Fill the mounted disk"
+	return "Fill the specified directory path or mount point"
 }
 
 func (*FillActionSpec) LongDesc() string {
-	return "Fill the mounted disk"
+	return "Fill the specified directory path or mount point. If the path is not directory or does not exist, an error message will be returned. Only one can be selected in --path and --mount-point"
 }
 
 func (*FillActionSpec) Flags() []exec.ExpFlagSpec {
 	return []exec.ExpFlagSpec{
 		&exec.ExpFlag{
 			Name:     "size",
-			Desc:     "fill size, unit is MB",
+			Desc:     "Disk fill size, unit is MB. The value is a positive integer without unit, for example, --size 1024",
 			Required: true,
 		},
+		&exec.ExpFlag{
+			Name: "path",
+			Desc: "The path of directory where the disk is populated",
+		},
+		// Mount-point flag in parent cannot be deleted because it needs to be adapted to the old version
 	}
 }
 
@@ -58,13 +63,24 @@ func (fae *FillActionExecutor) Exec(uid string, ctx context.Context, model *exec
 		return transport.ReturnFail(transport.Code[transport.ServerError], "channel is nil")
 	}
 	mountPoint := model.ActionFlags["mount-point"]
-	if mountPoint == "" {
-		mountPoint = "/"
-	}
-	if !util.IsExist(mountPoint) {
+	path := model.ActionFlags["path"]
+	if mountPoint == "" && path == "" {
 		return transport.ReturnFail(transport.Code[transport.IllegalParameters],
-			fmt.Sprintf("the %s mount point is not exist", mountPoint))
+			"must use --path or --mount-point to specify the directory")
 	}
+	if mountPoint != "" && path != "" {
+		return transport.ReturnFail(transport.Code[transport.IllegalParameters],
+			"only one can be select in --path and --mount-point")
+	}
+	directory := path
+	if directory == "" {
+		directory = mountPoint
+	}
+	if !util.IsDir(directory) {
+		return transport.ReturnFail(transport.Code[transport.IllegalParameters],
+			fmt.Sprintf("the %s directory does not exist or is not directory", directory))
+	}
+
 	size := model.ActionFlags["size"]
 	if size == "" {
 		return transport.ReturnFail(transport.Code[transport.IllegalParameters], "less size arg")
@@ -74,20 +90,20 @@ func (fae *FillActionExecutor) Exec(uid string, ctx context.Context, model *exec
 		return transport.ReturnFail(transport.Code[transport.IllegalParameters], "size must be positive integer")
 	}
 	if _, ok := exec.IsDestroy(ctx); ok {
-		return fae.stop(mountPoint, size, ctx)
+		return fae.stop(directory, size, ctx)
 	} else {
-		return fae.start(mountPoint, size, ctx)
+		return fae.start(directory, size, ctx)
 	}
 }
 
-func (fae *FillActionExecutor) start(mountPoint, size string, ctx context.Context) *transport.Response {
+func (fae *FillActionExecutor) start(directory, size string, ctx context.Context) *transport.Response {
 	return fae.channel.Run(ctx, path.Join(fae.channel.GetScriptPath(), fillDiskBin),
-		fmt.Sprintf("--mount-point %s --size %s --start", mountPoint, size))
+		fmt.Sprintf("--directory %s --size %s --start", directory, size))
 }
 
-func (fae *FillActionExecutor) stop(mountPoint, size string, ctx context.Context) *transport.Response {
+func (fae *FillActionExecutor) stop(directory, size string, ctx context.Context) *transport.Response {
 	return fae.channel.Run(ctx, path.Join(fae.channel.GetScriptPath(), fillDiskBin),
-		fmt.Sprintf("--mount-point %s --stop", mountPoint))
+		fmt.Sprintf("--directory %s --stop", directory))
 }
 
 func (fae *FillActionExecutor) SetChannel(channel exec.Channel) {

--- a/util/util.go
+++ b/util/util.go
@@ -77,10 +77,19 @@ func IsNil(i interface{}) bool {
 	return false
 }
 
-//IsExist return true if file exists
+//IsExist returns true if file exists
 func IsExist(fileName string) bool {
 	_, err := os.Stat(fileName)
 	return err == nil || os.IsExist(err)
+}
+
+// IsDir returns true if the path is directory
+func IsDir(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil || fileInfo == nil {
+		return false
+	}
+	return fileInfo.IsDir()
 }
 
 //GetUserHome return user home.


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See #169 for details

### Describe how you did it
Add `--path` flag to receive the directory where the disk occupied

### Describe how to verify it
`blade create disk fill --path /home/admin`
`blade create disk fill --path /`

We can specify any directory to fill disk.