### PR TITLE
feature: add destination ip flag

### DIFF
--- a/exec/os/bin/delaylossnetwork/delaylossnetwork.go
+++ b/exec/os/bin/delaylossnetwork/delaylossnetwork.go
@@ -13,6 +13,7 @@ import (
 )
 
 var dlNetInterface, dlLocalPort, dlRemotePort, dlExcludePort string
+var dlDestinationIp string
 var lossNetPercent, delayNetTime, delayNetOffset string
 var dlNetStart, dlNetStop bool
 
@@ -26,6 +27,7 @@ func main() {
 	flag.StringVar(&dlLocalPort, "local-port", "", "local ports, for example: 80,8080,8081")
 	flag.StringVar(&dlRemotePort, "remote-port", "", "remote ports, for example: 80,8080,8081")
 	flag.StringVar(&dlExcludePort, "exclude-port", "", "exclude ports, for example: 22,23")
+	flag.StringVar(&dlDestinationIp, "destination-ip", "", "destination ip")
 	flag.BoolVar(&dlNetStart, "start", false, "start delay")
 	flag.BoolVar(&dlNetStop, "stop", false, "stop delay")
 	util.AddDebugFlag()
@@ -42,7 +44,7 @@ func main() {
 		} else if delayNetTime != "" {
 			classRule = fmt.Sprintf("netem delay %sms %sms", delayNetTime, delayNetOffset)
 		}
-		startNet(dlNetInterface, classRule, dlLocalPort, dlRemotePort, dlExcludePort)
+		startNet(dlNetInterface, classRule, dlLocalPort, dlRemotePort, dlExcludePort, dlDestinationIp)
 	} else if dlNetStop {
 		stopNet(dlNetInterface)
 	} else {
@@ -52,10 +54,10 @@ func main() {
 
 var channel = exec.NewLocalChannel()
 
-func startNet(netInterface, classRule, localPort, remotePort, excludePort string) {
+func startNet(netInterface, classRule, localPort, remotePort, excludePort, destIp string) {
 	ctx := context.Background()
 	// assert localPort and remotePort
-	if localPort == "" && remotePort == "" && excludePort == "" {
+	if localPort == "" && remotePort == "" && excludePort == "" && destIp == "" {
 		response := channel.Run(ctx, "tc", fmt.Sprintf(`qdisc add dev %s root %s`, netInterface, classRule))
 		if !response.Success {
 			bin.PrintErrAndExit(response.Err)
@@ -64,19 +66,55 @@ func startNet(netInterface, classRule, localPort, remotePort, excludePort string
 		return
 	}
 	response := addQdiscForDL(channel, ctx, netInterface)
-	if localPort == "" && remotePort == "" && excludePort != "" {
-		response = addExcludePortFilterForDL(ctx, channel, netInterface, classRule, excludePort)
+	// only ip
+	if localPort == "" && remotePort == "" && excludePort == "" {
+		response = addIpFilterForDL(ctx, channel, netInterface, classRule, destIp)
 		bin.PrintOutputAndExit(response.Result.(string))
 		return
 	}
-	response = addLocalOrRemotePortForDL(ctx, channel, netInterface, classRule, localPort, remotePort)
+	ipRule := getIpRule(destIp)
+	// exclude
+	if localPort == "" && remotePort == "" && excludePort != "" {
+		response = addExcludePortFilterForDL(ctx, channel, netInterface, classRule, excludePort, ipRule)
+		bin.PrintOutputAndExit(response.Result.(string))
+		return
+	}
+	// local port or remote port
+	response = addLocalOrRemotePortForDL(ctx, channel, netInterface, classRule, localPort, remotePort, ipRule)
 	bin.PrintOutputAndExit(response.Result.(string))
+}
+
+func getIpRule(destIp string) string {
+	if destIp == "" {
+		return ""
+	}
+	return fmt.Sprintf("match ip dst %s", destIp)
+}
+
+// addIpFilterForDL
+func addIpFilterForDL(ctx context.Context, channel exec.Channel, netInterface string, classRule, destIp string) *transport.Response {
+	response := channel.Run(ctx, "tc",
+		fmt.Sprintf(`qdisc add dev %s parent 1:4 handle 40: %s`, netInterface, classRule))
+	if !response.Success {
+		stopNet(netInterface)
+		bin.PrintErrAndExit(response.Err)
+		return response
+	}
+	args := fmt.Sprintf(
+		`filter add dev %s parent 1: prio 4 protocol ip u32 match ip dst %s flowid 1:4`,
+		netInterface, destIp)
+	response = channel.Run(ctx, "tc", args)
+	if !response.Success {
+		stopDLNetFunc(netInterface)
+		bin.PrintErrAndExit(response.Err)
+	}
+	return response
 }
 
 var stopDLNetFunc = stopNet
 // addLocalOrRemotePortForDL creates class rule in 1:4 queue and add filter to the queue
 func addLocalOrRemotePortForDL(ctx context.Context, channel exec.Channel,
-	netInterface, classRule, localPort, remotePort string) *transport.Response {
+	netInterface, classRule, localPort, remotePort, ipRule string) *transport.Response {
 	response := channel.Run(ctx, "tc",
 		fmt.Sprintf(`qdisc add dev %s parent 1:4 handle 40: %s`, netInterface, classRule))
 	if !response.Success {
@@ -88,13 +126,14 @@ func addLocalOrRemotePortForDL(ctx context.Context, channel exec.Channel,
 	if localPort != "" {
 		ports := strings.Split(localPort, delimiter)
 		args := fmt.Sprintf(
-			`filter add dev %s parent 1: prio 4 protocol ip u32 match ip sport %s 0xffff flowid 1:4`, netInterface, ports[0])
+			`filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip sport %s 0xffff flowid 1:4`,
+			netInterface, ipRule, ports[0])
 		if len(ports) > 1 {
 			for i := 1; i < len(ports); i++ {
 				args = fmt.Sprintf(
 					`%s && \
-					tc filter add dev %s parent 1: prio 4 protocol ip u32 match ip sport %s 0xffff flowid 1:4`,
-					args, netInterface, ports[i])
+					tc filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip sport %s 0xffff flowid 1:4`,
+					args, netInterface, ipRule, ports[i])
 			}
 		}
 		response = channel.Run(ctx, "tc", args)
@@ -127,7 +166,7 @@ func addLocalOrRemotePortForDL(ctx context.Context, channel exec.Channel,
 
 // addExcludePortFilterForDL create class rule for each band and add filter to 1:4
 func addExcludePortFilterForDL(ctx context.Context, channel exec.Channel,
-	netInterface, classRule, excludePort string) *transport.Response {
+	netInterface, classRule, excludePort, ipRule string) *transport.Response {
 	args := fmt.Sprintf(
 		`qdisc add dev %s parent 1:1 %s && \
 			tc qdisc add dev %s parent 1:2 %s && \
@@ -135,12 +174,13 @@ func addExcludePortFilterForDL(ctx context.Context, channel exec.Channel,
 			tc qdisc add dev %s parent 1:4 handle 40: pfifo_fast`,
 		netInterface, classRule, netInterface, classRule, netInterface, classRule, netInterface)
 	ports := strings.Split(excludePort, delimiter)
+
 	for idx := range ports {
 		args = fmt.Sprintf(
 			`%s && \
-			tc filter add dev %s parent 1: prio 4 protocol ip u32 match ip sport %s 0xffff flowid 1:4 && \
-			tc filter add dev %s parent 1: prio 4 protocol ip u32 match ip dport %s 0xffff flowid 1:4`,
-			args, netInterface, ports[idx], netInterface, ports[idx])
+			tc filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip sport %s 0xffff flowid 1:4 && \
+			tc filter add dev %s parent 1: prio 4 protocol ip u32 %s match ip dport %s 0xffff flowid 1:4`,
+			args, netInterface, ipRule, ports[idx], netInterface, ipRule, ports[idx])
 	}
 
 	response := channel.Run(ctx, "tc", args)

--- a/exec/os/network.go
+++ b/exec/os/network.go
@@ -62,13 +62,17 @@ var commFlags = []exec.ExpFlagSpec{
 		Desc: "Exclude local ports. Support for configuring multiple ports, separated by commas or connector representing ranges, for example: 22,8000. This flag is invalid when --local-port or --remote-port is specified",
 	},
 	&exec.ExpFlag{
+		Name: "destination-ip",
+		Desc: "destination ip. Support for using mask to specify the ip range, for example, 192.168.1.0/24. You can also use 192.168.1.1 or 192.168.1.1/32 to specify it.",
+	},
+	&exec.ExpFlag{
 		Name:     "interface",
 		Desc:     "Network interface, for example, eth0",
 		Required: true,
 	},
 }
 
-func getCommArgs(localPort, remotePort, excludePort string, args string) (string, error) {
+func getCommArgs(localPort, remotePort, excludePort, destinationIp string, args string) (string, error) {
 	if localPort != "" {
 		localPorts, err := util.ParseIntegerListToStringSlice(localPort)
 		if err != nil {
@@ -89,6 +93,9 @@ func getCommArgs(localPort, remotePort, excludePort string, args string) (string
 			return "", err
 		}
 		args = fmt.Sprintf("%s --exclude-port %s", args, strings.Join(excludePorts, ","))
+	}
+	if destinationIp != "" {
+		args = fmt.Sprintf("%s --destination-ip %s", args, destinationIp)
 	}
 	return args, nil
 }

--- a/exec/os/network_delay.go
+++ b/exec/os/network_delay.go
@@ -73,16 +73,18 @@ func (de *NetworkDelayExecutor) Exec(uid string, ctx context.Context, model *exe
 	localPort := model.ActionFlags["local-port"]
 	remotePort := model.ActionFlags["remote-port"]
 	excludePort := model.ActionFlags["exclude-port"]
+	destIp := model.ActionFlags["destination-ip"]
 	if _, ok := exec.IsDestroy(ctx); ok {
 		return de.stop(netInterface, ctx)
 	} else {
-		return de.start(localPort, remotePort, excludePort, time, offset, netInterface, ctx)
+		return de.start(localPort, remotePort, excludePort, destIp, time, offset, netInterface, ctx)
 	}
 }
 
-func (de *NetworkDelayExecutor) start(localPort, remotePort, excludePort, time, offset, netInterface string, ctx context.Context) *transport.Response {
+func (de *NetworkDelayExecutor) start(localPort, remotePort, excludePort, destIp, time, offset, netInterface string,
+	ctx context.Context) *transport.Response {
 	args := fmt.Sprintf("--start --interface %s --time %s --offset %s --debug=%t", netInterface, time, offset, util.Debug)
-	args, err := getCommArgs(localPort, remotePort, excludePort, args)
+	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args)
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.IllegalParameters], err.Error())
 	}

--- a/exec/os/network_loss.go
+++ b/exec/os/network_loss.go
@@ -70,12 +70,14 @@ func (nle *NetworkLossExecutor) Exec(uid string, ctx context.Context, model *exe
 	localPort := model.ActionFlags["local-port"]
 	remotePort := model.ActionFlags["remote-port"]
 	excludePort := model.ActionFlags["exclude-port"]
-	return nle.start(dev, localPort, remotePort, excludePort, percent, ctx)
+	destIp := model.ActionFlags["destination-ip"]
+	return nle.start(dev, localPort, remotePort, excludePort, destIp, percent, ctx)
 }
 
-func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, excludePort, percent string, ctx context.Context) *transport.Response {
+func (nle *NetworkLossExecutor) start(netInterface, localPort, remotePort, excludePort, destIp, percent string,
+	ctx context.Context) *transport.Response {
 	args := fmt.Sprintf("--start --interface %s --percent %s", netInterface, percent)
-	args, err := getCommArgs(localPort, remotePort, excludePort, args)
+	args, err := getCommArgs(localPort, remotePort, excludePort, destIp, args)
 	if err != nil {
 		return transport.ReturnFail(transport.Code[transport.IllegalParameters], err.Error())
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
#181 

### Describe how you did it
1. Add `--destination-ip` flag
2. Add `match ip dst xxxx` command

### Describe how to verify it
`blade c network delay --time 3000 --interface eth0 --destination-ip 172.16.57.131 --local-port 8080`


### Special notes for reviews
