### PR TITLE
feature: Specify the repository when execute blade create docker

### DIFF
--- a/exec/docker/channel.go
+++ b/exec/docker/channel.go
@@ -3,12 +3,13 @@ package docker
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
-	"github.com/chaosblade-io/chaosblade/transport"
+
 	"github.com/chaosblade-io/chaosblade/exec"
+	"github.com/chaosblade-io/chaosblade/transport"
 	"github.com/chaosblade-io/chaosblade/version"
-	"path"
 )
 
 const (
@@ -22,6 +23,8 @@ const (
 const bladeHome = "/usr/local/chaosblade"
 const repository = "registry.cn-hangzhou.aliyuncs.com/chaosblade/chaosblade-agent"
 
+var NewDockerChannelFunc = NewDockerChannel
+
 type Channel struct {
 	localChannel exec.Channel
 	image        string
@@ -32,6 +35,11 @@ func NewDockerChannel(channel exec.Channel) *Channel {
 		localChannel: channel,
 		image:        fmt.Sprintf("%s:%s", repository, version.Ver),
 	}
+}
+
+func (c *Channel) Set(channel exec.Channel, image string) {
+	c.localChannel = channel
+	c.image = image
 }
 
 func (c *Channel) Run(ctx context.Context, script, args string) *transport.Response {

--- a/exec/docker/spec.go
+++ b/exec/docker/spec.go
@@ -1,9 +1,10 @@
 package docker
 
 import (
-	"github.com/chaosblade-io/chaosblade/exec"
 	"context"
 	"fmt"
+
+	"github.com/chaosblade-io/chaosblade/exec"
 )
 
 const (
@@ -60,7 +61,7 @@ type PreExecutor struct {
 
 func NewPreExecutor(channel exec.Channel) *PreExecutor {
 	return &PreExecutor{
-		DockerChannel: NewDockerChannel(channel),
+		DockerChannel: NewDockerChannelFunc(channel),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: yixy <youzhilane01@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Provide capacity：Specify the repository when execute blade create docker

### Does this pull request fix one issue?

Fixes #222 

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

redefine `docker.NewDockerChannel()` by using global variable `docker.NewDockerChannelFunc`. As follows, it can specify the repository when execute blade create docker.

```
func NewDockerChannelUser(channel exec.Channel) (c *docker.Channel) {
	c = &docker.Channel{}
	c.Set(channel, fmt.Sprintf("%s:%s", "xxx", version.Ver))
	return c
}

func main() {
	docker.NewDockerChannelFunc = NewDockerChannelUser
	baseCommand := cmd.CmdInit()
	if err := baseCommand.CobraCmd().Execute(); err != nil {
		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err.Error())
		os.Exit(1)
	}
}
```
