### PR TITLE
fix cpubind by taskset or cgroup.

### DIFF
--- a/exec/os/bin/burncpu/burncpu.go
+++ b/exec/os/bin/burncpu/burncpu.go
@@ -164,12 +164,14 @@ func runBurnCpu(ctx context.Context, cpuCount int, cpuPercent int, pidNeeded boo
 	if pidNeeded {
 		args = fmt.Sprintf("%s --cpu-processor %s", args, processor)
 	}
+
 	args = fmt.Sprintf(`%s > /dev/null 2>&1 &`, args)
 	response := channel.Run(ctx, "nohup", args)
 	if !response.Success {
 		stopBurnCpuFunc()
 		bin.PrintErrAndExit(response.Err)
 	}
+
 	if pidNeeded {
 		// parse pid
 		newCtx := context.WithValue(context.Background(), exec.ProcessKey, fmt.Sprintf("cpu-processor %s", processor))

--- a/exec/os/bin/burncpu/burncpu.go
+++ b/exec/os/bin/burncpu/burncpu.go
@@ -136,7 +136,7 @@ var stopBurnCpuFunc = stopBurnCpu
 
 var runBurnCpuFunc = runBurnCpu
 
-var bindBurnCpuFunc = bindBurnCpu
+var bindBurnCpuFunc = bindBurnCpuByTaskset
 
 var checkBurnCpuFunc = checkBurnCpu
 
@@ -192,8 +192,8 @@ func runBurnCpu(ctx context.Context, cpuCount int, cpuPercent int, pidNeeded boo
 }
 
 // bindBurnCpu by taskset command
-func bindBurnCpu(ctx context.Context, core string, pid int) {
-	response := channel.Run(ctx, "taskset", fmt.Sprintf("-cp %s %d", core, pid))
+func bindBurnCpuByTaskset(ctx context.Context, core string, pid int) {
+	response := channel.Run(ctx, "taskset", fmt.Sprintf("-a -cp %s %d", core, pid))
 	if !response.Success {
 		stopBurnCpuFunc()
 		bin.PrintErrAndExit(response.Err)

--- a/exec/os/bin/burncpu/burncpu_test.go
+++ b/exec/os/bin/burncpu/burncpu_test.go
@@ -101,7 +101,7 @@ func Test_bindBurnCpu(t *testing.T) {
 		T:                t,
 	}
 
-	bindBurnCpu(context.Background(), as.core, as.pid)
+	bindBurnCpuByTaskset(context.Background(), as.core, as.pid)
 	if exitCode != 1 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
 	}

--- a/exec/os/bin/burncpu/burncpu_test.go
+++ b/exec/os/bin/burncpu/burncpu_test.go
@@ -97,7 +97,7 @@ func Test_bindBurnCpu(t *testing.T) {
 
 	channel = &exec.MockLocalChannel{
 		Response:         transport.ReturnFail(transport.Code[transport.CommandNotFound], "taskset command not found"),
-		ExpectedCommands: []string{fmt.Sprintf(`taskset -cp 0 25233`)},
+		ExpectedCommands: []string{fmt.Sprintf(`taskset -a -cp 0 25233`)},
 		T:                t,
 	}
 

--- a/exec/os/bin/burncpu/forlinux/burncpu.go
+++ b/exec/os/bin/burncpu/forlinux/burncpu.go
@@ -82,7 +82,7 @@ var stopBurnCpuFunc = stopBurnCpu
 
 var runBurnCpuFunc = runBurnCpu
 
-var bindBurnCpuFunc = bindBurnCpu
+var bindBurnCpuFunc = bindBurnCpuByCpuset
 
 var checkBurnCpuFunc = checkBurnCpu
 
@@ -104,12 +104,14 @@ func startBurnCpu() {
 		control := cgroupNewFunc(realCores, cpuPercent)
 		for _, core := range cores {
 			pid := runBurnCpuFunc(ctx, cpuCount, true, core)
-			bindBurnCpuFunc(ctx, core, pid)
 			if err := control.Add(cgroups.Process{Pid: pid}); err != nil {
 				stopBurnCpuFunc()
 				bin.PrintErrAndExit(fmt.Sprintf("Add pid to cgroup error, %v", err))
 			}
 		}
+
+		bindBurnCpuFunc(control, cpuList)
+
 	} else {
 		pid := runBurnCpuFunc(ctx, cpuCount, true, "0")
 		control := cgroupNewFunc(cpuCount, cpuPercent)
@@ -157,11 +159,19 @@ func runBurnCpu(ctx context.Context, cpuCount int, pidNeeded bool, processor str
 }
 
 // bindBurnCpu by taskset command
-func bindBurnCpu(ctx context.Context, core string, pid int) {
-	response := channel.Run(ctx, "taskset", fmt.Sprintf("-cp %s %d", core, pid))
+func bindBurnCpuByTaskset(ctx context.Context, core string, pid int) {
+	response := channel.Run(ctx, "taskset", fmt.Sprintf("-a -cp %s %d", core, pid))
 	if !response.Success {
 		stopBurnCpuFunc()
 		bin.PrintErrAndExit(response.Err)
+	}
+}
+
+// bindBurnCpu by cpuset
+func bindBurnCpuByCpuset(cgctrl cgroups.Cgroup, cpuList string) {
+	if err := cgctrl.Update(&specs.LinuxResources{CPU: &specs.LinuxCPU{Cpus: cpuList}}); err != nil {
+		stopBurnCpuFunc()
+		bin.PrintErrAndExit(fmt.Sprintf("Bind core-list to cgroup error, %v", err))
 	}
 }
 

--- a/exec/os/bin/burncpu/forlinux/burncpu_test.go
+++ b/exec/os/bin/burncpu/forlinux/burncpu_test.go
@@ -29,7 +29,7 @@ func Test_startBurnCpu(t *testing.T) {
 	runBurnCpuFunc = func(ctx context.Context, cpuCount int, pidNeeded bool, processor string) int {
 		return 25233
 	}
-	bindBurnCpuFunc = func(ctx context.Context, core string, pid int) {}
+	bindBurnCpuFunc = func(cgctrl cgroups.Cgroup, cpulist string) {}
 	checkBurnCpuFunc = func(ctx context.Context) {}
 	cgroupNewFunc = func(int, int) cgroups.Cgroup { return new(CgroupMock) }
 	for _, tt := range tests {
@@ -96,11 +96,11 @@ func Test_bindBurnCpu(t *testing.T) {
 
 	channel = &exec.MockLocalChannel{
 		Response:         transport.ReturnFail(transport.Code[transport.CommandNotFound], "taskset command not found"),
-		ExpectedCommands: []string{fmt.Sprintf(`taskset -cp 0 25233`)},
+		ExpectedCommands: []string{fmt.Sprintf(`taskset -a -cp 0 25233`)},
 		T:                t,
 	}
 
-	bindBurnCpu(context.Background(), as.core, as.pid)
+	bindBurnCpuByTaskset(context.Background(), as.core, as.pid)
 	if exitCode != 1 {
 		t.Errorf("unexpected result %d, expected result: %d", exitCode, 1)
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
fix cpu bind not correct.

### Does this pull request fix one issue?

Fix #220 

### Describe how you did it

when use taskset for binding cpu :
man taskset:
-a, --all-tasks
              Set or retrieve the CPU affinity of all the tasks (threads) for a given PID.

add -a to taskset command.
```
response := channel.Run(ctx, "taskset", fmt.Sprintf("-a -cp %s %d", core, pid))
```

when use cgorup for binding cpu
update cpuset.cpus to bind:
```
cgctrl.Update(&specs.LinuxResources{CPU: &specs.LinuxCPU{Cpus: cpuList}});
```

### Describe how to verify it
taskset:
pidstat -p $pid 1 

cgroup:
```
cat  /sys/fs/cgroup/cpuset/chaosblade/cpuset.cpus
```
### Special notes for reviews
