### PR TITLE
Bugfix solve too many process for prepare jvm with jave home

### DIFF
--- a/exec/jvm/executor.go
+++ b/exec/jvm/executor.go
@@ -215,6 +215,9 @@ func CheckFlagValues(processName, processId string) (string, *spec.Response) {
 	}
 	if processName != "" {
 		ctx := context.WithValue(context.Background(), specchannel.ProcessKey, "java")
+                // set pecchannel.ExcludeProcessKey as "blade" to exclude pid of the blade command we run when querying the target application by processName
+                // If ExcludeProcessKey is not set, multiple pids might be returned (the blade command pid might be one of the pids.)
+                ctx = context.WithValue(ctx, specchannel.ExcludeProcessKey, "blade")
 		pids, err := specchannel.GetPidsByProcessName(processName, ctx)
 		if err != nil {
 			return processId, spec.ReturnFail(spec.Code[spec.GetProcessError], err.Error())

--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -155,23 +155,25 @@ func getUsername(pid string) (string, error) {
 }
 
 func getJavaBinAndJavaHome(javaHome string, ctx context.Context, pid string) (string, string) {
-	javaBin := "java"
-	if javaHome == "" {
-		javaHome = os.Getenv("JAVA_HOME")
-		javaBin = path.Join(javaHome, "bin/java")
-	}
-	if javaHome == "" {
-		psArgs := specchannel.GetPsArgs()
-		response := channel.Run(ctx, "ps", fmt.Sprintf(`%s | grep -w %s | grep java | grep -v grep | awk '{print $4}'`,
-			psArgs, pid))
-		if response.Success {
-			javaBin = strings.TrimSpace(response.Result.(string))
-		}
-		if strings.HasPrefix(javaBin, "/bin/java") {
-			javaHome = javaBin[:len(javaBin)-9]
-		}
-	}
-	return javaBin, javaHome
+        javaBin := "java"
+        if javaHome != "" {
+           javaBin = path.Join(javaHome, "bin/java")
+           return javaBin, javaHome
+        }
+        if javaHome = os.Getenv("JAVA_HOME"); javaHome != "" {
+           javaBin = path.Join(javaHome, "bin/java")
+           return javaBin, javaHome
+        }
+        psArgs := specchannel.GetPsArgs()
+        response := channel.Run(ctx, "ps", fmt.Sprintf(`%s | grep -w %s | grep java | grep -v grep | awk '{print $4}'`,
+                psArgs, pid))
+        if response.Success {
+                javaBin = strings.TrimSpace(response.Result.(string))
+        }
+        if strings.HasPrefix(javaBin, "/bin/java") {
+                javaHome = javaBin[:len(javaBin)-9]
+        }
+        return javaBin, javaHome
 }
 
 func Detach(port string) *spec.Response {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
       It solves the "too many process" error when calling ./blade prepare jvm --javaHome <javaPath> --process <process name> wich javaPath containing keyword "java"

     e.g: ./blade prepare jvm --javaHome /home/q/java/default --process pf_noah_webapp, this should find only one pid by  process keyword "pf_noah_webapp", but right now it finds two pids by process keyword "pf_noah_webapp".

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
    Fixes #288 
### Describe how you did it
      Use "blade" as keyword to exclude the false process when querying pids by process name.

### Describe how to verify it
       After applying this fix, use example command "sudo ./blade prepare jvm --javaHome /home/q/java/default --process pf_noah_webapp" to verify, and the result should be like

   {
    "code": 200,
    "success": true,
    "result": "537cd831b5e7c613"
}

  
   
      
### Special notes for reviews
