### PR TITLE
bugfix: fix compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build: pre_build build_cli build_os build_docker build_kubernetes build_java bui
 # alias
 cli: build_cli
 os: build_os
-os_darwin: build_darwin
+os_darwin: build_os_darwin
 docker: build_docker
 kubernetes: build_kubernetes
 java: build_java
@@ -79,8 +79,8 @@ cplus: build_cplus
 # for example: make build_with cli os_darwin
 build_with: pre_build
 
-# for example: make build_with cli os
-build_with_linux: pre_build
+# for example: make build_with_linux cli os
+build_with_linux: pre_build build_linux_with_arg
 
 # build chaosblade cli: blade
 build_cli:
@@ -177,6 +177,13 @@ build_linux:
 		-v $(shell echo -n ${GOPATH}):/go \
 		-w /go/src/github.com/chaosblade-io/chaosblade \
 		chaosblade-build-musl:latest
+
+build_linux_with_arg:
+	docker build -f build/image/musl/Dockerfile -t chaosblade-build-musl:latest build/image/musl
+	docker run --rm \
+		-v $(shell echo -n ${GOPATH}):/go \
+		-w /go/src/github.com/chaosblade-io/chaosblade \
+		chaosblade-build-musl:latest build_with $$ARGS
 
 # build chaosblade image for chaos
 build_image:

--- a/build/image/musl/Dockerfile
+++ b/build/image/musl/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 
 ENV CC /usr/local/musl/bin/musl-gcc
 ENV GOOS linux
-ENV mvn /usr/local/apache-maven-3.6.3/bin
 ENV java /usr/bin/java
+ENV PATH /usr/local/apache-maven-3.6.3/bin:$PATH
 
 ENTRYPOINT [ "make" ]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/chaosblade-io/chaosblade-exec-docker v0.4.2-0.20200110075138-e482011049e1
 	github.com/chaosblade-io/chaosblade-exec-os v0.4.1-0.20200131100637-6f11682eeada
-	github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200110075310-a6443f3732ca
+	github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200203091953-e633762449d8
 	github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20200110072855-4f767ce4e582
 	github.com/mattn/go-sqlite3 v1.10.1-0.20190217174029-ad30583d8387
 	github.com/prometheus/common v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20191216080032-f02da784564
 github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20191216080032-f02da7845646/go.mod h1:FE9gkAN0FmpANjoPl37hKcNHD103f0TKKN8Eq41KoLw=
 github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200110075310-a6443f3732ca h1:7kQ3CpXWRgxZnG2Y1YeKPpqqAgWc88UJmLni+YC8yJI=
 github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200110075310-a6443f3732ca/go.mod h1:gR9xIUGXXd0e4Witx4Zgga+LnovD7WDzUhN3pptaLAU=
+github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200203091953-e633762449d8 h1:BAmpJySSlgjyOCCjDtTSkoCbrtoHsCR7yhRycjicy0A=
+github.com/chaosblade-io/chaosblade-operator v0.4.1-0.20200203091953-e633762449d8/go.mod h1:gR9xIUGXXd0e4Witx4Zgga+LnovD7WDzUhN3pptaLAU=
 github.com/chaosblade-io/chaosblade-spec-go v0.4.0/go.mod h1:ybcCsIX1wZtPrH0IsI28yDNJ+AVPeDMUZlgw1HE++Ds=
 github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20191225105920-8d7c5f186698 h1:vO6v4Ku7WdMZvgQAhyBUM10i+nn7NNoO1rOQ5ORaGCg=
 github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20191225105920-8d7c5f186698/go.mod h1:/U5pOQIrBm82Xo8HB9mPjZHHira4dFiJzCB1UNkyPyk=


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See #298 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. install maven in Dockerfile for compiling chaosblade-exec-jvm project
2. fix `build_with_linux` target. We can use the following command to compile linux version for the specify projects on mac, for example, compile chaosblade cli and chaosblade-exec-os projects:
```
ARGS="cli os" make build_with_linux
```
The `ARGS` values contain `cli`, `os`, `docker`, `kubernetes`, `java`, `cplus`

or use ` make build_linux` to compile all projects

### Describe how to verify it


### Special notes for reviews
