### PR TITLE
feature: optimize chaosblade resource state flow in k8s experiments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ BLADE_EXEC_DOCKER_BRANCH=master
 
 # chaosblade-exec-kubernetes
 BLADE_OPERATOR_PROJECT=https://github.com/chaosblade-io/chaosblade-operator.git
-BLADE_OPERATOR_BRANCH=master
+BLADE_OPERATOR_BRANCH=feature-chaosblade-336
 
 # chaosblade-exec-jvm
 BLADE_EXEC_JVM_PROJECT=https://github.com/chaosblade-io/chaosblade-exec-jvm.git

--- a/cli/cmd/command_test.go
+++ b/cli/cmd/command_test.go
@@ -236,3 +236,7 @@ func (*MockSource) QueryPreparationRecords(target, status, limit string, asc boo
 func (*MockSource) QueryExperimentModelsByCommand(command, subCommand string, flags map[string]string) ([]*data.ExperimentModel, error) {
 	return make([]*data.ExperimentModel, 0), nil
 }
+
+func (*MockSource) DeleteExperimentModelByUid(uid string) error {
+	return nil
+}

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -62,6 +62,9 @@ type ExperimentSource interface {
 	// QueryExperimentModelsByCommand
 	// flags value contains necessary parameters generally
 	QueryExperimentModelsByCommand(command, subCommand string, flags map[string]string) ([]*ExperimentModel, error)
+
+	// DeleteExperimentModelByUid
+	DeleteExperimentModelByUid(uid string) error
 }
 
 const expTableDDL = `CREATE TABLE IF NOT EXISTS experiment (
@@ -289,4 +292,16 @@ func getExperimentModelsFrom(rows *sql.Rows) ([]*ExperimentModel, error) {
 		models = append(models, model)
 	}
 	return models, nil
+}
+
+func (s *Source) DeleteExperimentModelByUid(uid string) error {
+	stmt, err := s.DB.Prepare(`DELETE FROM experiment WHERE uid = ?`)
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(uid)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -101,7 +101,6 @@ func attach(pid, port string, ctx context.Context, javaHome string) (*spec.Respo
 	currUser, err := osuser.Current()
 	if err != nil {
 		logrus.Warnf("get current user info failed, %v", err)
-		//log.V(-1).Info("get current user info failed", "err_msg", err.Error())
 	}
 	var response *spec.Response
 	if currUser != nil && (currUser.Username == username) {
@@ -110,9 +109,6 @@ func attach(pid, port string, ctx context.Context, javaHome string) (*spec.Respo
 		if currUser != nil {
 			logrus.Debugf("current user name is %s, not equal %s, so use sudo command to execute",
 				currUser.Username, username)
-			//1=DEBUG
-			//log.V(1).Info("current user name is not equal username, so use sudo command to execute",
-			//	"current_username", currUser.Username, "username", username)
 		}
 		response = cl.Run(ctx, "sudo", fmt.Sprintf("-u %s %s %s", username, javaBin, javaArgs))
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200420053331-524a764ee2e1
 	github.com/chaosblade-io/chaosblade-exec-os v0.5.1-0.20200415114502-7d3f7b8d57cf
 	github.com/chaosblade-io/chaosblade-operator v0.5.1-0.20200420053347-b3c734a482c3
-	github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4
+	github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200423014225-aa78604fa1f2
 	github.com/mattn/go-sqlite3 v1.10.1-0.20190217174029-ad30583d8387
 	github.com/prometheus/common v0.2.0
 	github.com/shirou/gopsutil v2.19.9+incompatible
@@ -16,6 +16,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v11.0.0+incompatible
+	sigs.k8s.io/controller-runtime v0.1.12
 )
 
 // Pinned to kubernetes-1.13.11

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200415083603-6d694411
 github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200415111551-078ae08fddee/go.mod h1:r8uJ9dUyuNARD/DMuYOREbav/57KiGxTezIe5EnHYCI=
 github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200417015215-9570469b2ee9 h1:SnV7f9RvKrGMQJP8CmL049FlEV2YJ8QCi7sIUzLZFOk=
 github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200417015215-9570469b2ee9/go.mod h1:r8uJ9dUyuNARD/DMuYOREbav/57KiGxTezIe5EnHYCI=
+github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200420053331-524a764ee2e1 h1:It/fEM7n3U6Ef4kwxeGQlaC+Prv0uf4ky9xeZNXdqIc=
 github.com/chaosblade-io/chaosblade-exec-docker v0.5.1-0.20200420053331-524a764ee2e1/go.mod h1:r8uJ9dUyuNARD/DMuYOREbav/57KiGxTezIe5EnHYCI=
 github.com/chaosblade-io/chaosblade-exec-os v0.4.0 h1:yNUGhBFD3dA2+BulDCXL8fAyZvmiOp+HVOczvhVke1c=
 github.com/chaosblade-io/chaosblade-exec-os v0.4.0/go.mod h1:os4QqiAHjuzurJFH6JdMayqjMsNhUWD9LL8nlb0TEJk=
@@ -86,6 +87,7 @@ github.com/chaosblade-io/chaosblade-operator v0.5.0 h1:9EIJwVUNOzJlQjtlIBMDmAu7e
 github.com/chaosblade-io/chaosblade-operator v0.5.0/go.mod h1:3KP+68a/l/pM57Od3pl9iwVbyEx+7tHB736WvOPr2gk=
 github.com/chaosblade-io/chaosblade-operator v0.5.1-0.20200417092441-0e5a98b23726 h1:jEeYP9yTgriYdl5pxm1q6pZx0SaqmDsGyG/6TD80sdg=
 github.com/chaosblade-io/chaosblade-operator v0.5.1-0.20200417092441-0e5a98b23726/go.mod h1:dLwcN3ZHzN6Pecvft1/cCIapsEELqYE6B1D+q85dfEc=
+github.com/chaosblade-io/chaosblade-operator v0.5.1-0.20200420053347-b3c734a482c3 h1:i/Td/49wawgHpBION6oqVnAQGyiQxuPiCgWeVQQicw8=
 github.com/chaosblade-io/chaosblade-operator v0.5.1-0.20200420053347-b3c734a482c3/go.mod h1:dLwcN3ZHzN6Pecvft1/cCIapsEELqYE6B1D+q85dfEc=
 github.com/chaosblade-io/chaosblade-spec-go v0.4.0/go.mod h1:ybcCsIX1wZtPrH0IsI28yDNJ+AVPeDMUZlgw1HE++Ds=
 github.com/chaosblade-io/chaosblade-spec-go v0.4.1-0.20191225105920-8d7c5f186698 h1:vO6v4Ku7WdMZvgQAhyBUM10i+nn7NNoO1rOQ5ORaGCg=
@@ -100,6 +102,8 @@ github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413030726-04d0b230c5bc
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413030726-04d0b230c5bc/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4 h1:vIn/uqBty/+xv7Tei5cdjrpfuXpNTO6l37zNl3lPPuw=
 github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200413053019-c6149ff993b4/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200423014225-aa78604fa1f2 h1:0YQcrR+tnR/vY7E0lzEqqTJBuGpJdit7DB25zeGv3Cs=
+github.com/chaosblade-io/chaosblade-spec-go v0.5.1-0.20200423014225-aa78604fa1f2/go.mod h1:pNTL6HH4/ei+dshXnqxoNBUJ6jkDL+/7VYrobFVEyeQ=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/cgroups v0.0.0-20191011165608-5fbad35c2a7e/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -210,9 +214,11 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -230,6 +236,7 @@ github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gophercloud/gophercloud v0.0.0-20180330165814-781450b3c4fc/go.mod h1:3WdhXV3rUYy9p6AUW8d94kr+HS62Y4VL9mBnFxsD8q4=
 github.com/gophercloud/gophercloud v0.0.0-20190408160324-6c7ac67f8855/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
@@ -238,6 +245,7 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f h1:ShTPMJQes6tubcjzGMODIVG5hlrCeImaBnZzKF2N8SM=
 github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -334,6 +342,7 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/petar/GoLLRB v0.0.0-20130427215148-53be0d36a84c/go.mod h1:HUpKUBZnpzkdx0kD/+Yfuft+uD3zHGtXF/XJB14TUr4=
+github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Signed-off-by: xcaspar <x.caspar@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?
#336 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. Add `--force-remove`, `--target` and `--kubeconfig` flags to destroy command, support to delete experiment record and chaosblade resource in k8s cluster.
2. Support to destroy chaosblade resources in k8s cluster if the experiment records do not exist.

### Describe how to verify it
Use kubectl to create chaosblade resource and destroy by blade command.
```
// Destroy experiments according to local records, including k8s experiments
blade destroy UID

// Destroy experiments according to the chaosblade resource name in the k8s cluster, it is applicable to the case that the local record does not exist.
blade destory UID --target k8s --kubeconfig KUBECONFIG

// Destroy and forcibly remove experiments according to local records, including k8s experiments
blade destroy UID --force-remove

// Destroy and forcibly remove experiments according to the chaosblade resource name in the k8s cluster, it is applicable to the case that the local record does not exist.
blade destroy UID --force-remove --target k8s --kubeconfig KUBECONFIG
```

### Special notes for reviews
