### PR TITLE
feature: apdat to the new cplus executor

### DIFF
--- a/cli/cmd/prepare_cplus.go
+++ b/cli/cmd/prepare_cplus.go
@@ -29,10 +29,8 @@ import (
 
 type PrepareCPlusCommand struct {
 	baseCommand
-	port           int
-	scriptLocation string
-	waitTime       int
-	javaHome       string
+	port int
+	ip   string
 }
 
 func (pc *PrepareCPlusCommand) Init() {
@@ -46,14 +44,12 @@ func (pc *PrepareCPlusCommand) Init() {
 		Example: pc.prepareExample(),
 	}
 	pc.command.Flags().IntVarP(&pc.port, "port", "p", 8703, "the server port of cplus proxy")
-	pc.command.Flags().StringVarP(&pc.scriptLocation, "script-location", "l", "", "the script files directory")
-	pc.command.Flags().IntVarP(&pc.waitTime, "wait-time", "w", 6, "waiting time of preparation phase, unit is second")
-	pc.command.Flags().StringVarP(&pc.javaHome, "javaHome", "j", "", "the java jdk home path")
+	pc.command.Flags().StringVarP(&pc.ip, "ip", "i", "", "the server ip")
 	pc.command.MarkFlagRequired("port")
 }
 
 func (pc *PrepareCPlusCommand) prepareExample() string {
-	return `prepare cplus --port 8703 --wait-time 10`
+	return `prepare cplus --port 8703`
 }
 
 func (pc *PrepareCPlusCommand) prepareCPlus() error {
@@ -70,6 +66,6 @@ func (pc *PrepareCPlusCommand) prepareCPlus() error {
 				fmt.Sprintf("insert prepare record err, %s", err.Error()))
 		}
 	}
-	response := cplus.Prepare(portStr, pc.scriptLocation, pc.waitTime, pc.javaHome)
+	response := cplus.Prepare(portStr, pc.ip)
 	return handlePrepareResponse(record.Uid, pc.command, response)
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
The `chaosblade-exec-cplus` has been rewrited with golang, so modify the way of invoking the executor.

### Does this pull request fix one issue?
#380 

### Describe how you did it
Delete unused flags about the c++ executor and replace jar file to executable binary file.

### Describe how to verify it
Execute the following command to test:
```
blade prepare cplus --port 8370

blade create cplus delay --delayDuration 10 --breakLine tcp_server.cpp:33 --fileLocateAndName /home/admin/cplustest/cplus/server/server --forkMode parent --processName /server --initParams 9527

blade destroy 1f3e9a9363a98471

blade revoke 46077401d6e22404
```

### Special notes for reviews
