### PR TITLE
feature: #365 upgraded timeout flag

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -89,20 +89,16 @@ func (cc *CreateCommand) actionRunEFunc(target, scope string, actionCommand *act
 
 		// check timeout flag
 		tt := expModel.ActionFlags["timeout"]
+
 		if tt != "" {
 
 			//errNumber checks whether timout flag is parsable as Number
-			_, errNumber := strconv.ParseUint(tt, 10, 64)
+			if _, errNumber := strconv.ParseUint(tt, 10, 64); errNumber != nil {
 
-			//errNumber checks whether timout flag is parsable as Time
-			_, errTimeDuartion := time.ParseDuration(tt)
-
-			//error handling
-			if errNumber != nil && errTimeDuartion != nil {
-				if errTimeDuartion != nil {
-					return errTimeDuartion
+				//err checks whether timout flag is parsable as Time
+				if _, err := time.ParseDuration(tt); err != nil {
+					return err
 				}
-				return errNumber
 
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
This PR is for issue #365 . This PR converts the timeout flag from a time interval `String` to a `Number`. It would be simpler for developers to give timeout as 2m ( 2 minutes ), 2m30s  than 120 and 90.

### Does this pull request fix one issue?
Fixes #365 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Regex module is used parsing the string and get Number. Two regular expressions are used.

1. To verify whether the time interval is in the correct format. [here](https://www.debuggex.com/r/rHj0N3qflvDVuz_L)
![image](https://user-images.githubusercontent.com/46181010/85574083-14c22f80-b654-11ea-96e5-823da7bc60d9.png)

```^(\d+h)?(\d+m)?(\d+s)?$```

2. To form sub-strings for a timeout as Number. [here](https://www.debuggex.com/r/CPUCqkHD2JBuooCn)
![image](https://user-images.githubusercontent.com/46181010/85573927-ee9c8f80-b653-11ea-8a4e-78af9569ea2b.png)

```^(\d+h)?(\d+m)?(\d+s)?$```

### Describe how to verify it
Compile and test with `blade create cpu load --timeout 2m3s`
![image](https://user-images.githubusercontent.com/46181010/85572951-12130a80-b653-11ea-8e08-58718d4ccf47.png)

```sw4r4g@Acer-Avenger:/mnt/s/docker/test/chaosblade-0.6.0$ ./blade status a41bc92641c90a88
{
        "code": 200,
        "success": true,
        "result": {
                "Uid": "a41bc92641c90a88",
                "Command": "cpu",
                "SubCommand": "fullload",
                "Flag": " --timeout=1m --cpu-percent=20",
                "Status": "Destroyed",
                "Error": "",
                "CreateTime": "2020-06-24T19:41:24.480988+05:30",
                "UpdateTime": "2020-06-24T19:42:31.5633272+05:30"
        }
}
```
### Special notes for reviews.
