### PR TITLE
feature: change jvm sandbox default namespace

### DIFF
--- a/exec/jvm/executor.go
+++ b/exec/jvm/executor.go
@@ -32,7 +32,7 @@ import (
 	"github.com/chaosblade-io/chaosblade/data"
 )
 
-const DefaultUri = "sandbox/default/module/http/chaosblade"
+const DefaultUri = "sandbox/" + DefaultNamespace + "/module/http/chaosblade"
 
 // Executor for jvm experiment
 type Executor struct {

--- a/exec/jvm/sandbox.go
+++ b/exec/jvm/sandbox.go
@@ -36,7 +36,7 @@ import (
 // attach sandbox to java process
 var cl = channel.NewLocalChannel()
 
-const DefaultNamespace = "default"
+const DefaultNamespace = "chaosblade"
 
 func Attach(uid, port, javaHome, pid string) (*spec.Response, string) {
 	// refresh


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

when we use  chaosblade(chaosblade-exec-jvm) and jvm-sandbox-repeater same time,  there is a namespace conflict, which makes it unavailable. Because the default namespace of the two agents is "default", I want to modify the "default"namespace.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
change chaosblade-exec-jvm default namespace from "default" to "chaosblade"

### Describe how to verify it


### Special notes for reviews
