### PR TITLE
feat: add custom db flag to support using mysql db for experiment data storage

### DIFF
--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/chaosblade-io/chaosblade/data"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,14 @@ func (cli *Cli) setFlags() {
 	flags := cli.rootCmd.PersistentFlags()
 	flags.BoolVarP(&util.Debug, "debug", "d", false, "Set client to DEBUG mode")
 	//flags.StringVarP(&util.LogLevel, "log-level", "l", "info", "level of logging wanted. 1=DEBUG, 0=INFO, -1=WARN, A higher verbosity level means a log message is less important.")
+	flags.StringVar(&data.Type, "db-type", "sqlite3", "Use specific db type to store experiment data, support: mysql/sqlite3")
+	flags.StringVar(&data.Host, "db-host", "127.0.0.1", "If remote db server like mysql used for db-type, set the host of the db server")
+	flags.IntVar(&data.Port, "db-port", 3306, "If remote db server like mysql used for db-type, set the port of the db server")
+	flags.StringVar(&data.Database, "db-name", "chaosblade", "If remote db server like mysql used for db-type, set the target db name of the db server")
+	flags.StringVar(&data.Username, "db-user", "root", "If remote db server like mysql used for db-type, set the username for db connection")
+	flags.StringVar(&data.Password, "db-pwd", "", "If remote db server like mysql used for db-type, set the password for db connection (default \"\")")
+	flags.IntVar(&data.Timeout, "db-timeout", 60, "If remote db server like mysql used for db-type, set the timeout for db connection")
+	flags.StringVar(&data.DatPath, "dat-path", util.GetProgramPath(), "If default or local db like sqlite3 used for db-type, set the directory path to save chaosblade.dat file")
 }
 
 //Run command

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -84,7 +84,17 @@ func (bc *baseCommand) recordExpModel(commandPath string, expModel *spec.ExpMode
 		}
 	}
 
-	flagsInline := spec.ConvertExpMatchersToString(expModel, func() map[string]spec.Empty {
+	// filter db flags, not to record in experiment values
+	toRecordExpModel := expModel
+	delete(toRecordExpModel.ActionFlags, "db-type")
+	delete(toRecordExpModel.ActionFlags, "db-host")
+	delete(toRecordExpModel.ActionFlags, "db-port")
+	delete(toRecordExpModel.ActionFlags, "db-name")
+	delete(toRecordExpModel.ActionFlags, "db-user")
+	delete(toRecordExpModel.ActionFlags, "db-pwd")
+	delete(toRecordExpModel.ActionFlags, "db-timeout")
+	delete(toRecordExpModel.ActionFlags, "dat-path")
+	flagsInline := spec.ConvertExpMatchersToString(toRecordExpModel, func() map[string]spec.Empty {
 		return make(map[string]spec.Empty)
 	})
 	time := time.Now().Format(time.RFC3339Nano)

--- a/exec/cplus/executor.go
+++ b/exec/cplus/executor.go
@@ -101,11 +101,23 @@ func (e *Executor) destroyUrl(port, uid string) string {
 	return url
 }
 
-var db = data.GetSource()
+//取消直接调用 data.GetSource() 的方式，会导致 GetSource() 在运行 cobra.Command 之前执行而无法获取到 flag 参数。由于不能和 cmd package
+//循环依赖所以没法使用 cmd.GetDS()，且没有该工程中没有公共的 util，所以每个用到 data source 的地方都需要重复一遍 GetDS()，所以更好的方式
+//应该是把 data package 的部分放到 spec-go 里面去，并在 spec-go 里面提供 util.GetDS() 来使用
+//var db = data.GetSource()
+var ds data.SourceI
+
+// GetDS returns dataSource
+func GetDS() data.SourceI {
+	if ds == nil {
+		ds = data.GetSource()
+	}
+	return ds
+}
 
 func (e *Executor) getPortFromDB(uid string, model *spec.ExpModel) (string, *spec.Response) {
 	port := model.ActionFlags["port"]
-	record, err := db.QueryRunningPreByTypeAndProcess("cplus", port, "")
+	record, err := GetDS().QueryRunningPreByTypeAndProcess("cplus", port, "")
 	if err != nil {
 		util.Errorf(uid, util.GetRunFuncName(), spec.DatabaseError.Sprintf("query", err))
 		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/chaosblade-io/chaosblade-exec-os v1.4.0
 	github.com/chaosblade-io/chaosblade-operator v1.4.0
 	github.com/chaosblade-io/chaosblade-spec-go v1.4.0
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/mattn/go-sqlite3 v1.10.1-0.20190217174029-ad30583d8387
 	github.com/olekukonko/tablewriter v0.0.5-0.20201029120751-42e21c7531a3
 	github.com/shirou/gopsutil v3.21.6+incompatible

--- a/go.sum
+++ b/go.sum
@@ -521,6 +521,8 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
add db-type flag to support using different database, currently include mysql,sqlite3(default):
    1. support using mysql to be storage of experiment data, so that multiple chaosblade deployment can be used as the same time with the same remote db instead of local storage.
    2. support setting custom sqlite3 dat filepath, which is useful for the data persistence scene and version upgrading with the same data.

Because of:
1. the sqliite3 file in the directory of every version's program path, it is not friendly for version upgrading.
2. local sqlite3 can not guarantee data reliability and is not accessable for multiple chaosblade-tool deployments.
### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
1. add custom flags about db set.
2. use mysql driver and update sql.
3. update data.GetSource() calling, make it after flags parsing.

### Describe how to verify it


### Special notes for reviews
