### PR TITLE
Custom db and log

### DIFF
--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
+	"github.com/chaosblade-io/chaosblade/data"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +47,14 @@ func (cli *Cli) setFlags() {
 	flags := cli.rootCmd.PersistentFlags()
 	flags.BoolVarP(&util.Debug, "debug", "d", false, "Set client to DEBUG mode")
 	//flags.StringVarP(&util.LogLevel, "log-level", "l", "info", "level of logging wanted. 1=DEBUG, 0=INFO, -1=WARN, A higher verbosity level means a log message is less important.")
+	flags.StringVar(&data.Type, "db-type", "sqlite3", "Use specific db type to store experiment data, support: mysql/sqlite3")
+	flags.StringVar(&data.Host, "db-host", "127.0.0.1", "If remote db server like mysql used for db-type, set the host of the db server")
+	flags.IntVar(&data.Port, "db-port", 3306, "If remote db server like mysql used for db-type, set the port of the db server")
+	flags.StringVar(&data.Database, "db-name", "chaosblade", "If remote db server like mysql used for db-type, set the target db name of the db server")
+	flags.StringVar(&data.Username, "db-user", "root", "If remote db server like mysql used for db-type, set the username for db connection")
+	flags.StringVar(&data.Password, "db-pwd", "", "If remote db server like mysql used for db-type, set the password for db connection (default \"\")")
+	flags.IntVar(&data.Timeout, "db-timeout", 60, "If remote db server like mysql used for db-type, set the timeout for db connection")
+	flags.StringVar(&data.DatPath, "dat-path", util.GetProgramPath(), "If default or local db like sqlite3 used for db-type, set the directory path to save chaosblade.dat file")
 }
 
 //Run command

--- a/cli/cmd/cli.go
+++ b/cli/cmd/cli.go
@@ -55,6 +55,7 @@ func (cli *Cli) setFlags() {
 	flags.StringVar(&data.Password, "db-pwd", "", "If remote db server like mysql used for db-type, set the password for db connection (default \"\")")
 	flags.IntVar(&data.Timeout, "db-timeout", 60, "If remote db server like mysql used for db-type, set the timeout for db connection")
 	flags.StringVar(&data.DatPath, "dat-path", util.GetProgramPath(), "If default or local db like sqlite3 used for db-type, set the directory path to save chaosblade.dat file")
+	flags.StringVar(&util.LogPath, "log-path", util.GetProgramPath(), "Use log-path to set custom path for saving chaosblade logs")
 }
 
 //Run command

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -84,7 +84,17 @@ func (bc *baseCommand) recordExpModel(commandPath string, expModel *spec.ExpMode
 		}
 	}
 
-	flagsInline := spec.ConvertExpMatchersToString(expModel, func() map[string]spec.Empty {
+	// filter db flags, not to record in experiment values
+	toRecordExpModel := expModel
+	delete(toRecordExpModel.ActionFlags, "db-type")
+	delete(toRecordExpModel.ActionFlags, "db-host")
+	delete(toRecordExpModel.ActionFlags, "db-port")
+	delete(toRecordExpModel.ActionFlags, "db-name")
+	delete(toRecordExpModel.ActionFlags, "db-user")
+	delete(toRecordExpModel.ActionFlags, "db-pwd")
+	delete(toRecordExpModel.ActionFlags, "db-timeout")
+	delete(toRecordExpModel.ActionFlags, "dat-path")
+	flagsInline := spec.ConvertExpMatchersToString(toRecordExpModel, func() map[string]spec.Empty {
 		return make(map[string]spec.Empty)
 	})
 	time := time.Now().Format(time.RFC3339Nano)

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -148,7 +148,11 @@ func (bc *baseCommand) AddCommand(child Command) {
 	child.Init()
 	childCmd := child.CobraCmd()
 	childCmd.PreRun = func(cmd *cobra.Command, args []string) {
-		util.InitLog(util.Blade)
+		if cmd.Flag("log-path").Value.String() != "" {
+			util.InitLog(util.Custom)
+		} else {
+			util.InitLog(util.Blade)
+		}
 	}
 	childCmd.SilenceUsage = true
 	childCmd.DisableFlagsInUseLine = true

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -57,21 +57,6 @@ func (bc *baseCommand) Name() string {
 	return bc.command.Name()
 }
 
-var ds data.SourceI
-
-// GetDS returns dataSource
-func GetDS() data.SourceI {
-	if ds == nil {
-		ds = data.GetSource()
-	}
-	return ds
-}
-
-// SetDS for test
-func SetDS(source data.SourceI) {
-	ds = source
-}
-
 // recordExpModel
 func (bc *baseCommand) recordExpModel(commandPath string, expModel *spec.ExpModel) (commandModel *data.ExperimentModel,
 	response *spec.Response) {
@@ -113,7 +98,7 @@ func (bc *baseCommand) recordExpModel(commandPath string, expModel *spec.ExpMode
 		CreateTime: time,
 		UpdateTime: time,
 	}
-	err = GetDS().InsertExperimentModel(commandModel)
+	err = data.GetSource().InsertExperimentModel(commandModel)
 	if err != nil {
 		return nil, spec.ResponseFailWithFlags(spec.DatabaseError, "insert", err)
 	}
@@ -134,7 +119,7 @@ func (bc *baseCommand) generateUid() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	model, err := GetDS().QueryExperimentModelByUid(uid)
+	model, err := data.GetSource().QueryExperimentModelByUid(uid)
 	if err != nil {
 		return "", err
 	}

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -94,6 +94,7 @@ func (bc *baseCommand) recordExpModel(commandPath string, expModel *spec.ExpMode
 	delete(toRecordExpModel.ActionFlags, "db-pwd")
 	delete(toRecordExpModel.ActionFlags, "db-timeout")
 	delete(toRecordExpModel.ActionFlags, "dat-path")
+	delete(toRecordExpModel.ActionFlags, "log-path")
 	flagsInline := spec.ConvertExpMatchersToString(toRecordExpModel, func() map[string]spec.Empty {
 		return make(map[string]spec.Empty)
 	})

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -124,7 +124,7 @@ func (cc *CreateCommand) actionRunEFunc(target, scope string, actionCommand *act
 				logrus.Infof("can not execute nohup, uid is null")
 				return spec.ResponseFailWithFlags(spec.ParameterLess, UidFlag)
 			} else {
-				model, err = GetDS().QueryExperimentModelByUid(uid)
+				model, err = data.GetSource().QueryExperimentModelByUid(uid)
 				if err == nil {
 					delete(expModel.ActionFlags, NohupFlag)
 				}
@@ -186,12 +186,12 @@ func (cc *CreateCommand) actionRunEFunc(target, scope string, actionCommand *act
 
 			if !response.Success {
 				// update status
-				checkError(GetDS().UpdateExperimentModelByUid(model.Uid, Error, response.Err))
+				checkError(data.GetSource().UpdateExperimentModelByUid(model.Uid, Error, response.Err))
 				endpointCallBack(endpoint, model.Uid, response)
 				return response
 			}
 			// update status
-			checkError(GetDS().UpdateExperimentModelByUid(model.Uid, Success, response.Err))
+			checkError(data.GetSource().UpdateExperimentModelByUid(model.Uid, Success, response.Err))
 			response.Result = model.Uid
 			cmd.Println(response.Print())
 			endpointCallBack(endpoint, model.Uid, response)
@@ -203,7 +203,7 @@ func (cc *CreateCommand) actionRunEFunc(target, scope string, actionCommand *act
 func endpointCallBack(endpoint, uid string, response *spec.Response) {
 	if endpoint != "" {
 		logrus.Infof("report response: %s to endpoint: %s", response.Print(), endpoint)
-		experimentModel, _ := GetDS().QueryExperimentModelByUid(uid)
+		experimentModel, _ := data.GetSource().QueryExperimentModelByUid(uid)
 		body, err := json.Marshal(experimentModel)
 		if err != nil {
 			logrus.Warningf("create post body %s failed, %v", response.Print(), err)

--- a/cli/cmd/destroy.go
+++ b/cli/cmd/destroy.go
@@ -70,7 +70,7 @@ func (dc *DestroyCommand) Init() {
 func (dc *DestroyCommand) runDestroyWithUid(cmd *cobra.Command, args []string) error {
 	uid := args[0]
 	logrus.Infof("destroy by %s uid, force-remove: %t, target: %s", uid, dc.forceRemove, dc.expTarget)
-	model, err := GetDS().QueryExperimentModelByUid(uid)
+	model, err := data.GetSource().QueryExperimentModelByUid(uid)
 	lowerExpTarget := strings.ToLower(dc.expTarget)
 	isK8sTarget := lowerExpTarget == "kubernetes" || lowerExpTarget == "k8s"
 	if err != nil || model == nil {
@@ -192,7 +192,7 @@ func (dc *DestroyCommand) checkAndForceRemoveForK8sExp(name, kubeconfig string) 
 // checkAndForceRemoveForExpRecord deletes experiment record by uid if force-remove is true
 func (dc *DestroyCommand) checkAndForceRemoveForExpRecord(uid string) error {
 	if dc.forceRemove {
-		return GetDS().DeleteExperimentModelByUid(uid)
+		return data.GetSource().DeleteExperimentModelByUid(uid)
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (dc *DestroyCommand) destroyExperiment(uid string, executor spec.Executor, 
 		return response
 	}
 	// return result
-	checkError(GetDS().UpdateExperimentModelByUid(uid, Destroyed, ""))
+	checkError(data.GetSource().UpdateExperimentModelByUid(uid, Destroyed, ""))
 	return nil
 }
 
@@ -332,12 +332,12 @@ func (dc *DestroyCommand) actionRunEFunc(target, scope string, _ *actionCommand,
 		}
 		// update status by finding related records
 		logrus.Infof("destroy by model: %+v, command: %s, subCommand: %s", expModel, command, subCommand)
-		experimentModels, err := GetDS().QueryExperimentModelsByCommand(command, subCommand, expModel.ActionFlags)
+		experimentModels, err := data.GetSource().QueryExperimentModelsByCommand(command, subCommand, expModel.ActionFlags)
 		if err != nil {
 			logrus.Warningf("destroy success but query records failed, %v", err)
 		} else {
 			for _, record := range experimentModels {
-				checkError(GetDS().UpdateExperimentModelByUid(record.Uid, Destroyed, ""))
+				checkError(data.GetSource().UpdateExperimentModelByUid(record.Uid, Destroyed, ""))
 			}
 		}
 		cmd.Println(spec.ReturnSuccess(expModel).Print())

--- a/cli/cmd/prepare.go
+++ b/cli/cmd/prepare.go
@@ -74,7 +74,7 @@ func insertPrepareRecord(prepareType string, processName, port, processId string
 		CreateTime:  time.Now().Format(time.RFC3339Nano),
 		UpdateTime:  time.Now().Format(time.RFC3339Nano),
 	}
-	err = GetDS().InsertPreparationRecord(record)
+	err = data.GetSource().InsertPreparationRecord(record)
 	if err != nil {
 		return nil, err
 	}
@@ -84,10 +84,10 @@ func insertPrepareRecord(prepareType string, processName, port, processId string
 func handlePrepareResponseWithoutExit(uid string, cmd *cobra.Command, response *spec.Response) error {
 	response.Result = uid
 	if !response.Success {
-		GetDS().UpdatePreparationRecordByUid(uid, Error, response.Err)
+		data.GetSource().UpdatePreparationRecordByUid(uid, Error, response.Err)
 		return response
 	}
-	err := GetDS().UpdatePreparationRecordByUid(uid, Running, "")
+	err := data.GetSource().UpdatePreparationRecordByUid(uid, Running, "")
 	if err != nil {
 		logrus.Warningf("update preparation record error: %s", err.Error())
 	}
@@ -97,10 +97,10 @@ func handlePrepareResponseWithoutExit(uid string, cmd *cobra.Command, response *
 func handlePrepareResponse(uid string, cmd *cobra.Command, response *spec.Response) error {
 	response.Result = uid
 	if !response.Success {
-		GetDS().UpdatePreparationRecordByUid(uid, Error, response.Err)
+		data.GetSource().UpdatePreparationRecordByUid(uid, Error, response.Err)
 		return response
 	}
-	err := GetDS().UpdatePreparationRecordByUid(uid, Running, "")
+	err := data.GetSource().UpdatePreparationRecordByUid(uid, Running, "")
 	if err != nil {
 		logrus.Warningf("update preparation record error: %s", err.Error())
 		//log.V(-1).Info("update preparation record error", "err_msg", err.Error())
@@ -111,9 +111,9 @@ func handlePrepareResponse(uid string, cmd *cobra.Command, response *spec.Respon
 }
 
 func updatePreparationPort(uid, port string) error {
-	return GetDS().UpdatePreparationPortByUid(uid, port)
+	return data.GetSource().UpdatePreparationPortByUid(uid, port)
 }
 
 func updatePreparationPid(uid, pid string) error {
-	return GetDS().UpdatePreparationPidByUid(uid, pid)
+	return data.GetSource().UpdatePreparationPidByUid(uid, pid)
 }

--- a/cli/cmd/prepare_cplus.go
+++ b/cli/cmd/prepare_cplus.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"github.com/chaosblade-io/chaosblade/data"
 	"strconv"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
@@ -54,7 +55,7 @@ func (pc *PrepareCPlusCommand) prepareExample() string {
 
 func (pc *PrepareCPlusCommand) prepareCPlus() error {
 	portStr := strconv.Itoa(pc.port)
-	record, err := GetDS().QueryRunningPreByTypeAndProcess(PrepareCPlusType, portStr, "")
+	record, err := data.GetSource().QueryRunningPreByTypeAndProcess(PrepareCPlusType, portStr, "")
 	if err != nil {
 		util.Errorf("", util.GetRunFuncName(), spec.DatabaseError.Sprintf("query", err))
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)

--- a/cli/cmd/prepare_jvm.go
+++ b/cli/cmd/prepare_jvm.go
@@ -89,7 +89,7 @@ func (pc *PrepareJvmCommand) prepareJvm() error {
 		return response
 	}
 	pc.processId = pid
-	record, err := GetDS().QueryRunningPreByTypeAndProcess(PrepareJvmType, pc.processName, pc.processId)
+	record, err := data.GetSource().QueryRunningPreByTypeAndProcess(PrepareJvmType, pc.processName, pc.processId)
 	if err != nil {
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
@@ -244,7 +244,7 @@ func (pc *PrepareJvmCommand) invokeAttaching(port string, uid string) {
 }
 */
 func createPostBody(uid string) ([]byte, error) {
-	preparationRecord, err := GetDS().QueryPreparationByUid(uid)
+	preparationRecord, err := data.GetSource().QueryPreparationByUid(uid)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/revoke.go
+++ b/cli/cmd/revoke.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/chaosblade-io/chaosblade/data"
 	"strings"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/channel"
@@ -49,7 +50,7 @@ func (rc *RevokeCommand) Init() {
 
 func (rc *RevokeCommand) runRevoke(args []string) error {
 	uid := args[0]
-	record, err := GetDS().QueryPreparationByUid(uid)
+	record, err := data.GetSource().QueryPreparationByUid(uid)
 	if err != nil {
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
@@ -74,14 +75,14 @@ func (rc *RevokeCommand) runRevoke(args []string) error {
 		return spec.ResponseFailWithFlags(spec.ParameterIllegal, "type", record.ProgramType, "not support the type")
 	}
 	if response.Success {
-		checkError(GetDS().UpdatePreparationRecordByUid(uid, Revoked, ""))
+		checkError(data.GetSource().UpdatePreparationRecordByUid(uid, Revoked, ""))
 	} else if strings.Contains(response.Err, "connection refused") {
 		// sandbox has been detached, reset response value
 		response = spec.ReturnSuccess("success")
-		checkError(GetDS().UpdatePreparationRecordByUid(uid, Revoked, ""))
+		checkError(data.GetSource().UpdatePreparationRecordByUid(uid, Revoked, ""))
 	} else {
 		// other failed reason
-		checkError(GetDS().UpdatePreparationRecordByUid(uid, record.Status, fmt.Sprintf("revoke failed. %s", response.Err)))
+		checkError(data.GetSource().UpdatePreparationRecordByUid(uid, record.Status, fmt.Sprintf("revoke failed. %s", response.Err)))
 		return response
 	}
 	rc.command.Println(response.Print())

--- a/cli/cmd/server_start.go
+++ b/cli/cmd/server_start.go
@@ -97,7 +97,13 @@ func (ssc *StartServerCommand) start() error {
 	}
 	if len(pids) == 0 {
 		// read logs
-		logFile, err := util.GetLogFile(util.Blade)
+		var logFile string
+		var err error
+		if ssc.command.Flag("log-path").Value.String() != "" {
+			logFile, err = util.GetLogFile(util.Custom)
+		} else {
+			logFile, err = util.GetLogFile(util.Blade)
+		}
 		if err != nil {
 			return spec.ResponseFailWithFlags(spec.OsCmdExecFailed, startServerKey,
 				"start blade server failed and can't get log file")

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"github.com/chaosblade-io/chaosblade/data"
 	"os"
 
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
@@ -80,23 +81,23 @@ func (sc *StatusCommand) runStatus(command *cobra.Command, args []string) error 
 	switch sc.commandType {
 	case "create", "destroy", "c", "d":
 		if uid != "" {
-			result, err = GetDS().QueryExperimentModelByUid(uid)
+			result, err = data.GetSource().QueryExperimentModelByUid(uid)
 		} else {
-			result, err = GetDS().QueryExperimentModels(sc.target, sc.action, sc.flag, sc.status, sc.limit, sc.asc)
+			result, err = data.GetSource().QueryExperimentModels(sc.target, sc.action, sc.flag, sc.status, sc.limit, sc.asc)
 		}
 	case "prepare", "revoke", "p", "r":
 		if uid != "" {
-			result, err = GetDS().QueryPreparationByUid(uid)
+			result, err = data.GetSource().QueryPreparationByUid(uid)
 		} else {
-			result, err = GetDS().QueryPreparationRecords(sc.target, sc.status, sc.action, sc.flag, sc.limit, sc.asc)
+			result, err = data.GetSource().QueryPreparationRecords(sc.target, sc.status, sc.action, sc.flag, sc.limit, sc.asc)
 		}
 	default:
 		if uid == "" {
 			return spec.ResponseFailWithFlags(spec.ParameterLess, "type|uid", "must specify the right type or uid")
 		}
-		result, err = GetDS().QueryExperimentModelByUid(uid)
+		result, err = data.GetSource().QueryExperimentModelByUid(uid)
 		if util.IsNil(result) || err != nil {
-			result, err = GetDS().QueryPreparationByUid(uid)
+			result, err = data.GetSource().QueryPreparationByUid(uid)
 		}
 	}
 	if err != nil {

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -71,7 +71,7 @@ const expTableDDL = `CREATE TABLE IF NOT EXISTS experiment (
 	id INTEGER PRIMARY KEY %s,
 	uid VARCHAR(32) UNIQUE,
 	command VARCHAR(16) NOT NULL,
-	sub_command VARCHAR(16),
+	sub_command VARCHAR(32),
 	flag VARCHAR(512),
 	status VARCHAR(16),
 	error VARCHAR(512),

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -72,7 +72,7 @@ const expTableDDL = `CREATE TABLE IF NOT EXISTS experiment (
 	uid VARCHAR(32) UNIQUE,
 	command VARCHAR(16) NOT NULL,
 	sub_command VARCHAR(16),
-	flag VARCHAR(256),
+	flag VARCHAR(512),
 	status VARCHAR(16),
 	error VARCHAR(512),
 	create_time VARCHAR(32),

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -19,6 +19,7 @@ package data
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -93,16 +94,16 @@ var insertExpDML = `INSERT INTO
 func (s *Source) CheckAndInitExperimentTable() {
 	exists, err := s.ExperimentTableExists()
 	if err != nil {
-		logrus.Fatalf(err.Error())
-		//log.Error(err, "ExperimentTableExists err")
-		//os.Exit(1)
+		logrus.Errorf("ExperimentTableExists err, %s", err.Error())
+		fmt.Println(err.Error())
+		os.Exit(-1)
 	}
 	if !exists {
 		err = s.InitExperimentTable()
 		if err != nil {
-			logrus.Fatalf(err.Error())
-			//log.Error(err, "InitExperimentTable err")
-			//os.Exit(1)
+			logrus.Errorf("InitExperimentTable err, %s", err.Error())
+			fmt.Println(err.Error())
+			os.Exit(-1)
 		}
 	}
 }

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -71,7 +71,7 @@ const expTableDDL = `CREATE TABLE IF NOT EXISTS experiment (
 	id INTEGER PRIMARY KEY %s,
 	uid VARCHAR(32) UNIQUE,
 	command VARCHAR(16) NOT NULL,
-	sub_command VARCHAR(32),
+	sub_command VARCHAR(64),
 	flag VARCHAR(512),
 	status VARCHAR(16),
 	error VARCHAR(512),

--- a/data/experiment.go
+++ b/data/experiment.go
@@ -75,8 +75,8 @@ const expTableDDL = `CREATE TABLE IF NOT EXISTS experiment (
 	flag VARCHAR(512),
 	status VARCHAR(16),
 	error VARCHAR(512),
-	create_time VARCHAR(32),
-	update_time VARCHAR(32)
+	create_time VARCHAR(64),
+	update_time VARCHAR(64)
 )`
 
 var expIndexDDL = []string{

--- a/data/preparation.go
+++ b/data/preparation.go
@@ -264,8 +264,12 @@ func (s *Source) QueryRunningPreByTypeAndProcess(programType string, processName
 	var query = `SELECT * FROM preparation WHERE program_type = ? and status = "Running"`
 	var rows *sql.Rows
 	var err error
-	if processId != "" || processName != "" {
-		query = fmt.Sprintf(`%s and (pid = ? OR process = ?)`, query)
+	if processId != "" && processName != "" {
+		query = fmt.Sprintf(`%s and pid = ? and process = ?`, query)
+	} else if processId != "" {
+		query = fmt.Sprintf(`%s and pid = ?`, query)
+	} else if processName != "" {
+		query = fmt.Sprintf(`%s and process = ?`, query)
 		rows, err = s.DB.Query(query, programType, processId, processName)
 	} else {
 		rows, err = s.DB.Query(query, programType)
@@ -276,8 +280,12 @@ func (s *Source) QueryRunningPreByTypeAndProcess(programType string, processName
 			return nil, err
 		}
 		defer stmt.Close()
-		if processId != "" || processName != "" {
+		if processId != "" && processName != "" {
 			rows, err = stmt.Query(programType, processId, processName)
+		} else if processId != "" {
+			rows, err = stmt.Query(programType, processId)
+		} else if processName != "" {
+			rows, err = stmt.Query(programType, processName)
 		} else {
 			rows, err = stmt.Query(programType)
 		}

--- a/data/preparation.go
+++ b/data/preparation.go
@@ -266,10 +266,10 @@ func (s *Source) QueryRunningPreByTypeAndProcess(programType string, processName
 	var err error
 	if processId != "" && processName != "" {
 		query = fmt.Sprintf(`%s and pid = ? and process = ?`, query)
-		rows, err = s.DB.Query(programType, processId, processName)
+		rows, err = s.DB.Query(query, programType, processId, processName)
 	} else if processId != "" {
 		query = fmt.Sprintf(`%s and pid = ?`, query)
-		rows, err = s.DB.Query(programType, processId)
+		rows, err = s.DB.Query(query, programType, processId)
 	} else if processName != "" {
 		query = fmt.Sprintf(`%s and process = ?`, query)
 		rows, err = s.DB.Query(query, programType, processName)

--- a/data/preparation.go
+++ b/data/preparation.go
@@ -84,8 +84,8 @@ const preparationTableDDL = `CREATE TABLE IF NOT EXISTS preparation (
 	port       VARCHAR(8),
 	status     VARCHAR(16),
     error 	   VARCHAR(512),
-	create_time VARCHAR(32),
-	update_time VARCHAR(32),
+	create_time VARCHAR(64),
+	update_time VARCHAR(64),
 	pid 	   VARCHAR(8)
 )`
 

--- a/data/preparation.go
+++ b/data/preparation.go
@@ -266,11 +266,13 @@ func (s *Source) QueryRunningPreByTypeAndProcess(programType string, processName
 	var err error
 	if processId != "" && processName != "" {
 		query = fmt.Sprintf(`%s and pid = ? and process = ?`, query)
+		rows, err = s.DB.Query(programType, processId, processName)
 	} else if processId != "" {
 		query = fmt.Sprintf(`%s and pid = ?`, query)
+		rows, err = s.DB.Query(programType, processId)
 	} else if processName != "" {
 		query = fmt.Sprintf(`%s and process = ?`, query)
-		rows, err = s.DB.Query(query, programType, processId, processName)
+		rows, err = s.DB.Query(query, programType, processName)
 	} else {
 		rows, err = s.DB.Query(query, programType)
 	}

--- a/data/source.go
+++ b/data/source.go
@@ -105,16 +105,17 @@ func getConnection() *sql.DB {
 		break
 	default:
 		if _, err := os.Stat(DatPath); err != nil {
-			fmt.Printf("stat dat-path failed: %s", err)
+			logrus.Errorf("stat dat-path failed: %s", err.Error())
+			fmt.Println(err.Error())
 			os.Exit(-1)
 		}
 		database, err = sql.Open("sqlite3", path.Join(DatPath, dataFile))
 		break
 	}
 	if err != nil {
-		logrus.Fatalf("open data file err, %s", err.Error())
-		//log.Error(err, "open data file err")
-		//os.Exit(1)
+		logrus.Errorf("open database err, %s", err.Error())
+		fmt.Println(err.Error())
+		os.Exit(-1)
 	}
 	database.SetMaxOpenConns(20)
 	database.SetMaxIdleConns(2)

--- a/exec/cplus/executor.go
+++ b/exec/cplus/executor.go
@@ -101,23 +101,9 @@ func (e *Executor) destroyUrl(port, uid string) string {
 	return url
 }
 
-//取消直接调用 data.GetSource() 的方式，会导致 GetSource() 在运行 cobra.Command 之前执行而无法获取到 flag 参数。由于不能和 cmd package
-//循环依赖所以没法使用 cmd.GetDS()，且没有该工程中没有公共的 util，所以每个用到 data source 的地方都需要重复一遍 GetDS()，所以更好的方式
-//应该是把 data package 的部分放到 spec-go 里面去，并在 spec-go 里面提供 util.GetDS() 来使用
-//var db = data.GetSource()
-var ds data.SourceI
-
-// GetDS returns dataSource
-func GetDS() data.SourceI {
-	if ds == nil {
-		ds = data.GetSource()
-	}
-	return ds
-}
-
 func (e *Executor) getPortFromDB(uid string, model *spec.ExpModel) (string, *spec.Response) {
 	port := model.ActionFlags["port"]
-	record, err := GetDS().QueryRunningPreByTypeAndProcess("cplus", port, "")
+	record, err := data.GetSource().QueryRunningPreByTypeAndProcess("cplus", port, "")
 	if err != nil {
 		util.Errorf(uid, util.GetRunFuncName(), spec.DatabaseError.Sprintf("query", err))
 		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)

--- a/exec/cplus/executor.go
+++ b/exec/cplus/executor.go
@@ -101,11 +101,23 @@ func (e *Executor) destroyUrl(port, uid string) string {
 	return url
 }
 
-var db = data.GetSource()
+//取消直接调用 data.GetSource() 的方式，会导致 GetSource() 在运行 cobra.Command 之前执行而无法获取到 flag 参数。由于不能和 cmd package
+//循环依赖所以没法使用 cmd.GetDS()，且没有该工程中没有公共的 util，所以每个用到 data source 的地方都需要重复一遍 GetDS()，所以更好的方式
+//应该是把 data package 的部分放到 spec-go 里面去，并在 spec-go 里面提供 util.GetDS() 来使用
+//var db = data.GetSource()
+var ds data.SourceI
+
+// GetDS returns dataSource
+func GetDS() data.SourceI {
+	if ds == nil {
+		ds = data.GetSource()
+	}
+	return ds
+}
 
 func (e *Executor) getPortFromDB(uid string, model *spec.ExpModel) (string, *spec.Response) {
 	port := model.ActionFlags["port"]
-	record, err := db.QueryRunningPreByTypeAndProcess("cplus", port, "")
+	record, err := GetDS().QueryRunningPreByTypeAndProcess("cplus", port, "")
 	if err != nil {
 		util.Errorf(uid, util.GetRunFuncName(), spec.DatabaseError.Sprintf("query", err))
 		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/chaosblade-io/chaosblade-exec-os v1.5.0
 	github.com/chaosblade-io/chaosblade-operator v1.5.0
 	github.com/chaosblade-io/chaosblade-spec-go v1.5.0
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/mattn/go-sqlite3 v1.10.1-0.20190217174029-ad30583d8387
 	github.com/olekukonko/tablewriter v0.0.5-0.20201029120751-42e21c7531a3
 	github.com/shirou/gopsutil v3.21.6+incompatible

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/chaosblade-io/chaosblade-exec-os v1.5.0
 	github.com/chaosblade-io/chaosblade-operator v1.5.0
 	github.com/chaosblade-io/chaosblade-spec-go v1.5.0
-	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/mattn/go-sqlite3 v1.10.1-0.20190217174029-ad30583d8387
 	github.com/olekukonko/tablewriter v0.0.5-0.20201029120751-42e21c7531a3
 	github.com/shirou/gopsutil v3.21.6+incompatible

--- a/go.sum
+++ b/go.sum
@@ -531,6 +531,8 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

add db-type flag to support using different database, currently include mysql,sqlite3(default):

support using mysql to be storage of experiment data, so that multiple chaosblade deployment can be used as the same time with the same remote db instead of local storage.
support setting custom sqlite3 dat filepath, which is useful for the data persistence scene and version upgrading with the same data.
add log-path flag to set custom path for saving chaosblade logs:

support using custom path to save chaosblade logs, so that logs can make persistence storage with sure path instead of in chaosblade binary directory.
Because of:

the sqliite3 file of logs file in the directory of every version's program path, it is not friendly for version upgrading.
local sqlite3 can not guarantee data reliability and is not accessable for multiple chaosblade-tool deployments.

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

add custom flags about db set and log-path set..
update sql with mysql driver used and update data.GetSource() calling, make it after flags parsing.

### Describe how to verify it

![image](https://user-images.githubusercontent.com/20470818/151285311-dbb403d9-f5af-4a63-b83a-bd049bbb8089.png)


### Special notes for reviews
