### PR TITLE
docs: Add english documents.

### DIFF
--- a/docs/beginner_guide_CN.md
+++ b/docs/beginner_guide_CN.md
@@ -1,4 +1,4 @@
-欢迎关注 chaosblade 项目，这篇文章将带你快速掌握 chaosblade 工具的使用
+欢迎关注 chaosblade 项目！这篇文章将带你快速掌握 chaosblade 工具的使用。
 
 # 下载 chaosblade
 
@@ -11,19 +11,16 @@
 进入解压后的文件夹，可以看到以下内容：
 ```
 ├── bin
-│   ├── chaos_burncpu
-│   ├── chaos_burnio
-│   ├── chaos_changedns
-│   ├── chaos_delaynetwork
-│   ├── chaos_dropnetwork
-│   ├── chaos_filldisk
-│   ├── chaos_killprocess
-│   ├── chaos_lossnetwork
-│   ├── jvm.spec.yaml
-│   └── tools.jar
+│   ├── chaos_fuse
+│   ├── chaos_os
+│   ├── nsexec
+│   └── strace
 ├── blade
 └── lib
-    └── sandbox
+│    ├── cplus
+│    └── sandbox
+├── logs
+└── yaml
 ```
 
 其中 blade 是可执行文件，即 chaosblade 工具的 cli，混沌实验执行的工具。执行 `./blade help` 可以查看支持命令有哪些：
@@ -59,7 +56,7 @@ Use "blade [command] --help" for more information about a command.
 {"code":200,"success":true,"result":"7c1f7afc281482c8"}
 ```
 
-通过 `top` 命令查看 CPU 使用率
+通过 `top` 命令查看 CPU 使用率：
 ```
 CPU usage: 93.79% user, 6.20% sys, 0.0% idle
 ```
@@ -69,7 +66,7 @@ CPU usage: 93.79% user, 6.20% sys, 0.0% idle
 ./blade destroy 7c1f7afc281482c8 
 ```
 
-返回以下结果，表示停止实验成功
+返回以下结果，表示停止实验成功:
 ```
 {"code":200,"success":true,"result":"command: cpu fullload --debug false --help false"}
 ``` 
@@ -135,7 +132,7 @@ Global Flags:
 ```
 ./blade create dubbo delay --time 3000 --service com.alibaba.demo.HelloService --methodname hello --consumer --process dubbo.consumer
 ```
-返回以下结果，表示执行成功；访问 `http://localhost:8080/hello?msg=world` 验证是否延迟 3 秒
+返回以下结果，表示执行成功；访问 `http://localhost:8080/hello?msg=world` 验证是否延迟 3 秒。
 ```
 {"code":200,"success":true,"result":"ec695fee1e458fc6"}
 ```
@@ -180,7 +177,7 @@ Global Flags:
 ```
 ./blade create dubbo throwCustomException --exception java.lang.Exception --service com.alibaba.demo.HelloService --methodname hello --consumer --process dubbo.consumer
 ```
-返回以下结果，访问 `http://localhost:8080/hello?msg=world` 验证是否异常
+返回以下结果，表示实验执行成功；访问 `http://localhost:8080/hello?msg=world` 验证是否异常
 ```
 {"code":200,"success":true,"result":"09dd96f4c062df69"}
 ```
@@ -211,7 +208,6 @@ Global Flags:
                 }
         ]
 }
-
 ```
 
 # FAQ
@@ -222,4 +218,4 @@ chaosblade 每次发布，相关的 changelog 和新版的包都会同步到 REL
 暂无支持计划，不过欢迎大家提相关支持的 issue，社区会根据大家的需求来决定是否支持。
 
 ### 执行 blade 命令报错： exec format error 或 cannot execute binary file 
-是由于 chaosblade 包和运行的平台不兼容造成的，请提 [ISSUE](https://github.com/chaosblade-io/chaosblade/issues)来告知我们，issue 中标注下载的 chaosblade 包版本和操作系统版本信息。
+这个问题是由于 chaosblade 包和运行的平台不兼容造成的，请提 [ISSUE](https://github.com/chaosblade-io/chaosblade/issues)来告知我们您遇到的问题，issue 中标注下载的 chaosblade 包版本和操作系统版本信息。

--- a/docs/beginner_guide_EN.md
+++ b/docs/beginner_guide_EN.md
@@ -1,0 +1,222 @@
+Welcome to the chaosblade project! this article will take you through the chaosblade tool quickly.
+
+# Download chaosblade
+
+Get the latest [release](https://github.com/chaosblade-io/chaosblade/releases) package of chaosblade, currently supported by linux/amd64 and darwin/64, and download the package for the corresponding platform.
+
+Just download and unzip it, no need to compile.
+
+# Using chaosblade
+When you enter the unzipped folder, you can see the following contents:
+```
+├── bin
+│   ├── chaos_fuse
+│   ├── chaos_os
+│   ├── nsexec
+│   └── strace
+├── blade
+└── lib
+│    ├── cplus
+│    └── sandbox
+├── logs
+└── yaml
+```
+
+where blade is the executable file, the cli of the chaosblade tool, the tool for chaos experiments. Execute `. /blade help` to see what commands are supported:
+
+```
+An easy to use and powerful chaos engineering experiment toolkit
+
+Usage:
+  blade [command]
+
+Available Commands:
+  create      Create a chaos engineering experiment
+  destroy     Destroy a chaos experiment
+  help        Help about any command
+  prepare     Prepare to experiment
+  revoke      Undo chaos engineering experiment preparation
+  status      Query preparation stage or experiment status
+  version     Print version info
+
+Flags:
+  -d, --debug   Set client to DEBUG mode
+  -h, --help    help for blade
+
+Use "blade [command] --help" for more information about a command.
+```
+
+## Perform your first chaos experiment
+Let's take a CPU full (100% CPU usage) exercise scenario as an example (!!! **Note, do not execute on the production system machine without knowing the impact surface**), and execute the following command to execute the experiment:
+
+```
+./blade create cpu fullload
+```
+
+Execution results return:
+```
+{"code":200,"success":true,"result":"7c1f7afc281482c8"}
+```
+
+View CPU usage with the `top` command:
+```
+CPU usage: 93.79% user, 6.20% sys, 0.0% idle
+```
+
+At this point the command is in effect, **Stop Chaos Experiment** and execute;
+```
+./blade destroy 7c1f7afc281482c8 
+```
+
+The following result is returned to indicate the success of the stop experiment:
+```
+CPU usage: 6.36% user, 4.74% sys, 88.88% idle 
+```
+
+A CPU full load walkthrough is completed.
+
+## Your second chaos experiment
+For this experiment, we walk through the Dubbo application, and our requirement is that the consumer calls the hello interface under the com.alibaba.demo.HelloService service with a delay of 3 seconds. Next, we download the Dubbo demo we need. 
+
+[dubbo-provider](https://chaosblade.oss-cn-hangzhou.aliyuncs.com/demo/dubbo-provider-1.0-SNAPSHOT.jar)  
+[dubbo-consumer](https://chaosblade.oss-cn-hangzhou.aliyuncs.com/demo/dubbo-consumer-1.0-SNAPSHOT.jar)
+
+After downloading, execute the following command to start the application. Note that you must start `dubbo-provider` first, and then `dubbo-consumer`:
+
+```
+# Start dubbo-provider
+nohup java -Djava.net.preferIPv4Stack=true -Dproject.name=dubbo-provider -jar dubbo-provider-1.0-SNAPSHOT.jar > provider.nohup.log 2>&1 &
+
+# Wait 2 seconds, then start dubbo-consumer
+nohup java -Dserver.port=8080 -Djava.net.preferIPv4Stack=true -Dproject.name=dubbo-consumer -jar dubbo-consumer-1.0-SNAPSHOT.jar > consumer.nohup.log 2>&1 &
+```
+Visit `http://localhost:8080/hello?msg=world` and return the following message indicating a successful start.
+```
+{
+    msg: "Dubbo Service: Hello world"
+}
+```
+
+Next, we will use the blade tool to perform chaos experiments. Before we can perform the experiments, we need to execute the prepare command to mount the required java agent.
+
+```
+./blade prepare jvm --process dubbo.consumer
+```
+The following results are returned to indicate successful experiment preparation:
+```
+{"code":200,"success":true,"result":"e669d57f079a00cc"}
+```
+We start implementing chaos experiments, and our requirement is that consumer calls to the `hello` interface under the `com.alibaba.demo.HelloService` service are delayed by 3 seconds.
+We execute `. /blade create dubbo delay -h` command to see the command usage for the dubbo call delay:
+``` 
+Usage:
+  blade create dubbo delay
+
+Flags:
+      --appname string      The consumer or provider application name
+      --consumer            To tag consumer role experiment.
+  -h, --help                help for delay
+      --methodname string   The method name in service interface
+      --offset string       delay offset for the time
+      --process string      Application process name
+      --provider            To tag provider experiment
+      --service string      The service interface
+      --time string         delay time (required)
+      --version string      the service version
+
+Global Flags:
+  -d, --debug   Set client to DEBUG mode
+```
+
+Calling the `hello` interface under the `com.alibaba.demo.HelloService` service is delayed by 3 seconds and we execute the following command.
+```
+./blade create dubbo delay --time 3000 --service com.alibaba.demo.HelloService --methodname hello --consumer --process dubbo.consumer
+```
+The following result is returned, indicating successful execution; visit `http://localhost:8080/hello?msg=world` to verify that the delay is 3 seconds.
+```
+{"code":200,"success":true,"result":"ec695fee1e458fc6"}
+```
+Explanation of the order to perform the experiment：
+* `--time`: 3000, indicates a delay of 3000 ms; the unit is ms
+* `--service`: com.alibaba.demo.HelloService, indicating the called service
+* `-methodname`: hello, indicating the service interface method
+* `--consumer`: indicates that the walkthrough is a dubbo consumer
+* `--process`: dubbo.consumer, indicating which application process to implement the chaos experiment on
+
+Stop the chaos experiment with the current delay and visit the url again to verify that it is back to normal.
+```
+./blade destroy ec695fee1e458fc6
+```
+
+We can also implement a call to that service to throw an exception by running `. /blade create dubbo throwCustomException -h` command to see help：
+```
+Throw custom exception with --exception option
+
+Usage:
+  blade create dubbo throwCustomException
+
+Aliases:
+  throwCustomException, tce
+
+Flags:
+      --appname string      The consumer or provider application name
+      --consumer            To tag consumer role experiment.
+      --exception string    Exception class inherit java.lang.Exception (required)
+  -h, --help                help for throwCustomException
+      --methodname string   The method name in service interface
+      --process string      Application process name
+      --provider            To tag provider experiment
+      --service string      The service interface
+      --version string      the service version
+
+Global Flags:
+  -d, --debug   Set client to DEBUG mode
+```
+The same parameters as the delay command are needed to walk through dubbo, but without the `--time` and with an additional `--exception` parameter.
+We simulate the call to the service we just made by throwing the `java.lang.Exception` exception:
+```
+./blade create dubbo throwCustomException --exception java.lang.Exception --service com.alibaba.demo.HelloService --methodname hello --consumer --process dubbo.consumer
+```
+The following result is returned, indicating successful execution of the experiment; visit `http://localhost:8080/hello?msg=world` to verify if there is an exception.
+```
+{"code":200,"success":true,"result":"09dd96f4c062df69"}
+```
+Stop this trial, access the request again and verify that it is restored.
+```
+./blade destroy 09dd96f4c062df69 
+
+```
+Finally, we undo the preparation for the experiment we just did, i.e., uninstall the Java Agent.
+```
+./blade revoke e669d57f079a00cc
+```
+If you can't find the UID returned by the previous prepare, execute `. /blade status --type prepare` command to query.
+```
+{
+        "code": 200,
+        "success": true,
+        "result": [
+                {
+                        "Uid": "e669d57f079a00cc",
+                        "ProgramType": "jvm",
+                        "Process": "dubbo.consumer",
+                        "Port": "59688",
+                        "Status": "Running",
+                        "Error": "",
+                        "CreateTime": "2019-03-29T16:19:37.284579975+08:00",
+                        "UpdateTime": "2019-03-29T17:05:14.183382945+08:00"
+                }
+        ]
+}
+```
+
+# FAQ
+### How to get the latest version
+Every time chaosblade is released, the related changelog and the new version of the package will be synchronized to RELEASE, which can be downloaded at [this address](https://github.com/chaosblade-io/chaosblade/releases).
+
+### Is there a support plan for the Windows platform
+There is no support plan, but you are welcome to raise relevant support issues, the community will decide whether to support according to your needs.
+
+### Executing the blade command reports an error: exec format error or cannot execute binary file 
+
+This problem is caused by an incompatibility between the chaosblade package and the running platform. Please inform us about the problem by mentioning [ISSUE](https://github.com/chaosblade-io/chaosblade/issues), and mark the issue with the downloaded chaosblade package version and The operating system version information is indicated in the issue.

--- a/docs/chaos_experiment_model_CN.md
+++ b/docs/chaos_experiment_model_CN.md
@@ -43,7 +43,7 @@ Toolkit.
 ```
 blade create dubbo delay --time 3000 --consumer --service com.example.HelloService --version 1.0.0
 ```
-* `dubbo`: 模型中的 target，对 dubbo 实施实验。
+* `dubbo`: 模型中的 target，对 dubbo 实施实验。
 * `delay`: 模型中的 action，执行延迟演练场景。
 * `--time`: 模型中 action 参数，指延迟时间。
 * `--consumer`、`--service`、`--version`：模型中的 matchers，实验规则匹配器。
@@ -56,7 +56,6 @@ blade create dubbo delay --time 3000 --consumer --service com.example.HelloServi
 
 ![模型简图](https://user-images.githubusercontent.com/3992234/56200214-ecfb3300-6070-11e9-9c33-a318eb305bd9.png)
 
-
 ## chaosblade 模型定义
 ```go
 type ExpModelCommandSpec interface {
@@ -66,11 +65,10 @@ type ExpModelCommandSpec interface {
 	// 支持的场景列表
 	Actions() []ExpActionCommandSpec
 
-	// ... 略
+	// ...
 }
 ```
 **注：** 一个组件混沌实验模型的定义，包含组件名称和所支持的实验场景列表。
-
 ```go
 type ExpActionCommandSpec interface {
 	// 演练场景名称
@@ -85,28 +83,26 @@ type ExpActionCommandSpec interface {
 	// Action 执行器
 	Executor(channel Channel) Executor
 
-        // ... 略
+    // ...
 }
 ```
 **注：** 一个实验场景 action 的定义，包含场景名称，场景所需参数和一些实验规则匹配器
-
 ```go
 type ExpFlagSpec interface {
-        // 参数名
+    // 参数名
 	FlagName() string
 
-        // 参数描述
+    // 参数描述
 	FlagDesc() string
 
-        // 是否需要参数值
+    // 是否需要参数值
 	FlagNoArgs() bool
 
-        // 是否是必要参数
+    // 是否是必要参数
 	FlagRequired() bool
 }
 ```
 **注：** 实验匹配器定义。
-
 
 ## chaosblade 模型具体实现
 拿 network 组件举例，network 作为混沌实验组件，目前包含网络延迟、网络屏蔽、网络丢包、DNS 篡改演练场景，则依据模型规范，具体实现为：
@@ -180,10 +176,8 @@ func (*DelayActionSpec) Executor(channel exec.Channel) exec.Executor {
 ```
 * `DelayActionSpec` 包含 2 个场景参数和 4 个规则匹配器。
 
-
 # 总结
 通过以上事例，可以看出此模型简单、易实现，并且可以覆盖目前已知的实验场景。后续可以对此模型进行完善，成为一个混沌实验标准。
-
 
 # 附录 A
 

--- a/docs/chaos_experiment_model_EN.md
+++ b/docs/chaos_experiment_model_EN.md
@@ -1,0 +1,195 @@
+Following this model, it is straightforward to perform a chaos experiment and control the minimum explosion radius of the experiment.The [chaosblade](https://github.com/chaosblade-io/chaosblade) and [chaosblade-exec-jvm](https://github.com/chaosblade-io/chaosblade-exec-jvm) projects are implemented according to this model.
+
+## Model Definition
+Before giving the model discuss the problem of implementing a chaos experiment explicitly.
+
+- What to do the chaos experiment on
+- What is the scope of the chaos experiment
+- What are the specific experiments to be performed
+- What are the matching conditions for the experiment to be effective?
+  
+For example, an application on a 10.0.0.1 machine with an IP address of 10.0.0.1 calls the com.example.HelloService@1.0.0 Dubbo service with a latency of 3s. Based on the list of problems above, the first thing that is clear is that you want to experiment with Dubbo component chaos, implementing the experiment on a single 10.0.0.1 machine, calling com. example.HelloService@1.0.0 service to simulate a 3s delay. By specifying the above, you can precisely implement a chaos experiment by abstracting the following model:
+
+<img width="572" alt="fault-injection model" src="https://user-images.githubusercontent.com/3992234/55319674-fd73b100-54a7-11e9-8a8c-15d0fb8f2758.png">
+
+* Target: The target of the experiment, the component on which the experiment takes place, such as container, application framework (Dubbo, Redis, Zookeeper), etc.
+* Scope: The scope of the experiment implementation, referring to the specific machine or cluster that triggers the experiment, etc.
+* Matcher: Experiment rule matcher, according to the configured Target, define the relevant experiment matching rules, can be configured multiple. As each Target may have its own special matching conditions, for example, HSF and Dubbo in the RPC domain can be matched according to the services provided by the service provider and the services invoked by the service consumer, and Redis in the caching domain can be matched according to set and get operations.
+* Action: refers to the specific scenario of the experiment simulation, Target is different, the implementation of the scenario is also different, for example, the disk, you can rehearse the disk full, disk IO read and write high, disk hardware failure, etc.. If it is an application, you can abstract the experimental scenarios such as delay, exception, return specified values (error codes, large objects, etc.), parameter tampering, repeated calls, etc.
+
+Returning to the above example, it can be described as a failure drill for a Dubbo component (Target), for an application on host 10.0.0.1 (Scope), calling the com.example.HelloService@1.0.0 (Matcher) service with a 3s delay (Action).
+
+The pseudo code can be written as follows：
+```java
+Toolkit.
+    // Target
+    dubbo.
+    // Scope
+    host("1.0.0.1").
+    // Matcher 
+    consumer().
+    // Matcher
+    service("com.example.HelloService").
+    // Matcher
+    version("1.0.0").
+    // Action
+    delay(3000);
+```
+
+# chaosblade mode implementation
+
+## chaosblade cli call
+For the above example, the chaosblade call command is:
+```
+blade create dubbo delay --time 3000 --consumer --service com.example.HelloService --version 1.0.0
+```
+- ```dubbo```: Target in the model, which performs experiments on dubbo.
+- ```delay```: The action in the model that executes the delayed walkthrough scenario.
+- ```--time```: action argument in the model, referring to the delay time.
+- ```--consumer```, ```--service```, ```--version```: matchers in the model, experimental rule matchers.
+  
+**Note**: Since chaosblade is a tool that executes on a single machine, the scope in the chaos experiment model defaults to the local machine and no further declarations are shown.
+
+## Chaosblade model structure diagram
+
+In order to have a more intuitive understanding, let's take a general look at the relationship between the models through the following model structure diagram. The core interface model is ExpModelCommandSpec, from which the two interfaces ExpActionCommandSpec and ExpFlagSpec are derived. The ExpModelCommandSpec has specific implementations such as cpu, network, disk, etc.; the ExpActionCommandSpec is such as fullload under cpu, etc.; the ExpFlagSpec is a variety of custom parameters, such as --timeout. For more detailed model definitions, please see the subsequent subsections.
+
+![模型简图](https://user-images.githubusercontent.com/3992234/56200214-ecfb3300-6070-11e9-9c33-a318eb305bd9.png)
+
+## chaosblade model definition
+```go
+type ExpModelCommandSpec interface {
+	// Component Name
+	Name() string
+
+	// List of supported scenarios
+	Actions() []ExpActionCommandSpec
+
+	// ... 
+}
+```
+**Note**: Definition of a component chaos experiment model with component names and a list of supported experiment scenarios.
+```
+type ExpActionCommandSpec interface {
+	// Experimental scene name
+	Name() string
+
+	// Rule Matcher List
+	Matchers() []ExpFlagSpec
+
+	// Action parameter List
+	Flags() []ExpFlagSpec
+
+	// Action Executor
+	Executor(channel Channel) Executor
+
+    // ...
+}
+```
+**Note**: Definition of an experimental scenario action, including the scenario name, the parameters required for the scenario and some experimental rule matchers
+```go
+type ExpFlagSpec interface {
+    // Parameter Name
+	FlagName() string
+
+    // Parameter Description
+	FlagDesc() string
+
+    // Whether parameter values are required
+	FlagNoArgs() bool
+
+    // Is it a required parameter
+	FlagRequired() bool
+}
+```
+**Note**: Experimental matcher definition.
+
+## Chaosblade model implementation
+Take the network component as an example, network as a chaos experiment component, currently contains network latency, network shielding, network packet loss, DNS tampering exercise scenarios, then according to the model specification, the specific implementation as follows.
+```go
+type NetworkCommandSpec struct {
+}
+
+func (*NetworkCommandSpec) Name() string {
+	return "network"
+}
+
+func (*NetworkCommandSpec) Actions() []exec.ExpActionCommandSpec {
+	return []exec.ExpActionCommandSpec{
+		&DelayActionSpec{},
+		&DropActionSpec{},
+		&DnsActionSpec{},
+		&LossActionSpec{},
+	}
+}
+
+```
+The network target defines four chaotic experiment scenarios, DelayActionSpec, DropActionSpec, DnsActionSpec, and LossActionSpec, where DelayActionSpec is defined as follows.
+
+```go
+type DelayActionSpec struct {
+}
+
+func (*DelayActionSpec) Name() string {
+	return "delay"
+}
+
+func (*DelayActionSpec) Matchers() []exec.ExpFlagSpec {
+	return []exec.ExpFlagSpec{
+		&exec.ExpFlag{
+			Name: "local-port",
+			Desc: "Port for external service",
+		},
+		&exec.ExpFlag{
+			Name: "remote-port",
+			Desc: "Port for invoking",
+		},
+		&exec.ExpFlag{
+			Name: "exclude-port",
+			Desc: "Exclude one local port, for example 22 port. This flag is invalid when --local-port or remote-port is specified",
+		},
+		&exec.ExpFlag{
+			Name:     "device",
+			Desc:     "Network device",
+			Required: true,
+		},
+	}
+}
+
+func (*DelayActionSpec) Flags() []exec.ExpFlagSpec {
+	return []exec.ExpFlagSpec{
+		&exec.ExpFlag{
+			Name:     "time",
+			Desc:     "Delay time, ms",
+			Required: true,
+		},
+		&exec.ExpFlag{
+			Name: "offset",
+			Desc: "Delay offset time, ms",
+		},
+	}
+}
+
+func (*DelayActionSpec) Executor(channel exec.Channel) exec.Executor {
+	return &NetworkDelayExecutor{channel}
+}
+```
+* `DelayActionSpec` contains 2 scene parameters and 4 rule matchers.
+
+## Summary
+The above examples show that this model is simple, easy to implement, and can cover the currently known experimental scenarios. This model can be improved later to become a standard for chaotic experiments.
+
+## Appendix A
+Application-level generic failure scenarios.
+
+* Delay
+* Exceptions
+* Returning a specific value
+* Modifying a parameter value
+* Repeated calls
+* try-catch block exceptions
+
+## Document Contributors
+[@xcaspar](https://github.com/xcaspar)  
+[@Cenyol](https://github.com/Cenyol)
+[@Super-long](https://github.com/Super-long)

--- a/docs/logic_flow_Introduction_CN.md
+++ b/docs/logic_flow_Introduction_CN.md
@@ -1,16 +1,14 @@
 # 逻辑流程简介
 
-了解完相关模型接口之后，在此之上我们可以继续简单的了解模型之间是如何进行交互，一条命令如：blade create cpu fullload输入回车之后，系统是如何一步步解析成对应的模型，并最终执行达到压测负载效果的。话不多说，看下图：
+了解完相关模型接口之后，在此之上我们可以继续简单的了解模型之间是如何进行交互，一条命令如：`blade create cpu fullload`输入回车之后，系统是如何一步步解析成对应的模型，并最终执行达到压测负载效果的。话不多说，看下图：
 
 ![流程简图V0.0.1](https://user-images.githubusercontent.com/3992234/56200113-bc1afe00-6070-11e9-82ef-860b68b14827.png)
-
 
 ## Cobra框架
 
 首先建议了解一下Cobra，它是go的一个开源工具库，提供简单的接口来创建强大现代的CLI接口，类似于git或者go工具。同时，它也是一个应用，用来生成个人应用框架，组织系统命令、子命令以及相关参数，关于cobra更多具体信息详见[这里官方说明](https://github.com/spf13/cobra)，从而开发以Cobra为基础的应用。Docker源码中使用了Cobra。
 
 上图中一开始的添加各种指令，诸如：version、prepare、revoke、create等，在项目源码中就是基于cobra进行实现的，然后再进行二级命令以及相关参数的封装逻辑。
-
 
 ## chaosblade 流程简介
 
@@ -41,7 +39,6 @@ create的子命令在前面的模型章节中对应于：ExpModelCommandSpec接�
 接上Model子命令，这一级二级子命令对应的接口模型为：ExpActionCommandSpec。比如cpu fullload, network delay和drop等。属于真正执行操作的命令，从其命名为动词上可看出。
 
 系统解析到这步之后，就会带上参数ExpFlagSpec去调用具体的bin目录下对应的命令，实现系统负载操作。
-
 
 ## 总结
 

--- a/docs/logic_flow_Introduction_EN.md
+++ b/docs/logic_flow_Introduction_EN.md
@@ -1,0 +1,53 @@
+# Logical Process Introduction
+
+After understanding the relevant model interface, we can continue to understand briefly how the models interact with each other. After entering a command such as `blade create cpu fullload`, how the system resolves into the corresponding model step by step, and finally executes to achieve the effect of pressure test load. Without further ado, see the following figure.
+
+![流程简图V0.0.1](https://user-images.githubusercontent.com/3992234/56200113-bc1afe00-6070-11e9-82ef-860b68b14827.png)
+
+## Cobra
+
+It is first recommended to know about Cobra, an open source tool library for go that provides a simple interface to create a powerful modern CLI interface, similar to git or go tools. It is also an application for generating personal application frameworks, organizing system commands, subcommands, and related parameters. For more specific information about cobra see [official description here](https://github.com/spf13/cobra) to develop Cobra-based applications. Cobra is used in the Docker source code.
+
+The above diagram begins with adding various commands, such as version, prepare, revoke, create, etc., in the project source code is based on cobra for implementation, and then the secondary commands and related parameters of the packaging logic.
+
+## chaosblade Process Introduction
+
+First of all, the program at the beginning, will add all kinds of basic commands, such as: version, prepare, revoke, create, etc., these commands in addition to create has a variety of secondary subcommands, the rest are the native Cobra command model, only one level of command with parameters to operate. These commands are relatively simple, the specific implementation can be seen directly in the source code, after familiar with the Cobra look at a glance to understand.
+
+In addition to the project source code and documentation, another way to understand chaosblade usage is to get help information through the constant help prompt. For example:
+
+```bash
+blade help
+blade create help
+blade create cpu help
+```
+
+After you type blade overwhelmed, help all the way down will have surprises, thanks to the gods to provide easter eggs!
+
+### Various create subcommands
+
+The subcommands of create correspond in the previous model section: ExpModelCommandSpec interface. The main categories are as follows.
+
+**OS commands** i.e. OS-level load commands, currently only supported for *nix systems, provide load commands for cpu, disk, network, mem, etc.
+
+**DockerOS commands** i.e. OS-level load commands in Docker containers, this is basically consistent with the above OS commands, as you can also find from the source code, it just makes a wrapper around the OS command object, and then it is stuffed into the Docker command object.
+
+And Jvm, k8s, etc., you can see that the name of this level of command is a noun, which echoes the meaning of the naming of the interface ExpModelCommandSpec, it is a target model operation object. In these model objects followed by the second-level subcommand is a variety of operational actions, such as fullload.
+
+### Action under Model object
+
+The interface model corresponding to this level 2 subcommand is ExpActionCommandSpec, such as cpu fullload, network delay and drop. It is a command that actually performs an action, as can be seen from its naming as a verb.
+
+After the system resolves to this step, it will take the parameter ExpFlagSpec to call the corresponding command in the specific bin directory to realize the system load operation.
+
+## Summary
+
+This paper first shows the general operation flow of the system through a logical flow sketch. Then it briefly introduces the functions of Cobra library and its role in this project. After that, it introduces the operation flow from the command structure at one level, please refer to the source code implementation for more details.
+
+## Reference
+
+- [Cobra Official Description](https://github.com/spf13/cobra)
+
+## Document Contributors
+[@Cenyol](https://github.com/Cenyol)
+[@Super-long](https://github.com/Super-long)


### PR DESCRIPTION
Signed-off-by: Super-long <0x4f4f4f4f@gmail.com>

### Describe what this PR does / why we need it

The fact that chaosblade lacks adequate English documentation is a huge problem, and I've seen criticism of this problem in more than one article. 
1. https://harness.io/blog/devops/chaos-engineering-tools/
2. https://www.gremlin.com/community/tutorials/chaos-engineering-tools-comparison/#chaosblade
3. ...


So I tried to translate the existing Chinese documentation, as well as start working on the implementation of the command documentation (described in another ISSUE), which will be a long process.

### Notes

The biggest advantage of chaosblade over other chaos engineering tools is its simplicity and ease of use, but the lack of adequate documentation is a matter of putting the cart before the horse.
