### PR TITLE
Fix prepare cplus process name

### DIFF
--- a/cli/cmd/prepare_cplus.go
+++ b/cli/cmd/prepare_cplus.go
@@ -63,7 +63,7 @@ func (pc *PrepareCPlusCommand) prepareCPlus() error {
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
 	if record == nil || record.Status != Running {
-		record, err = insertPrepareRecord(PrepareCPlusType, portStr, portStr, "")
+		record, err = insertPrepareRecord(PrepareCPlusType, pc.Name(), portStr, "")
 		if err != nil {
 			log.Errorf(ctx, util.GetRunFuncName(), spec.DatabaseError.Sprintf("insert", err))
 			return spec.ResponseFailWithFlags(spec.DatabaseError, "insert", err)


### PR DESCRIPTION
Signed-off-by: yangli <798862514@qq.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
repair the prepare cplus process name from the original port number to the real process name.

### Does this pull request fix one issue?

NONE

### Describe how you did it
replace the original port number with the process name

### Describe how to verify it
View the table preparation field process

### Special notes for reviews
NONE