### PR TITLE
refectroign: Error return function modification

### DIFF
--- a/cli/cmd/check_java.go
+++ b/cli/cmd/check_java.go
@@ -126,12 +126,12 @@ func (djc *CheckJavaCommand) checkJdk() error {
 		javaHome = strings.Trim(javaResult, "\n")
 		jdkVersion, err := djc.getJdkVersionFromJdkHome()
 		if err != nil {
-			return errors.New(fmt.Sprintf("check java jdk version failed! err: %s", err.Error()))
+			return fmt.Errorf("check java jdk version failed! err: %s", err.Error())
 		}
 
 		ok, err := djc.checkJdkVersion(jdkVersion)
 		if !ok || err != nil {
-			return errors.New(fmt.Sprintf("check java jdk version failed! err: %s", err.Error()))
+			return fmt.Errorf("check java jdk version failed! err: %s", err.Error())
 		}
 		return nil
 	}
@@ -139,17 +139,17 @@ func (djc *CheckJavaCommand) checkJdk() error {
 	// 3. check jdk by `java -version`
 	response = channel.NewLocalChannel().Run(context.Background(), "", cmdJavaVersion)
 	if !response.Success {
-		return errors.New(fmt.Sprintf("check java jdk version failed! err: %s", response.Err))
+		return fmt.Errorf("check java jdk version failed! err: %s", response.Err)
 	}
 	javaResult := response.Result.(string)
 
 	jdkVersion, err := djc.getJdkVersionFromJavaVer(string(javaResult))
 	if err != nil {
-		return errors.New(fmt.Sprintf("check java jdk version failed! err: %s", err.Error()))
+		return fmt.Errorf("check java jdk version failed! err: %s", err.Error())
 	}
 	ok, err := djc.checkJdkVersion(jdkVersion)
 	if !ok || err != nil {
-		return errors.New(fmt.Sprintf("check java jdk version failed! err: %s", err.Error()))
+		return fmt.Errorf("check java jdk version failed! err: %s", err.Error())
 	}
 	return nil
 }
@@ -229,8 +229,9 @@ func (djc *CheckJavaCommand) getJdkVersionFromJdkHome() (string, error) {
 }
 
 // get jdk version from `java version` eg: java version "1.8.0_261"
-//										   Java(TM) SE Runtime Environment (build 1.8.0_261-b12)
-//										   Java HotSpot(TM) 64-Bit Server VM (build 25.261-b12, mixed mode)
+//
+//	Java(TM) SE Runtime Environment (build 1.8.0_261-b12)
+//	Java HotSpot(TM) 64-Bit Server VM (build 25.261-b12, mixed mode)
 func (djc *CheckJavaCommand) getJdkVersionFromJavaVer(jdkVer string) (string, error) {
 	// 1. check `java version`
 	if jdkVer == "" {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


- Replaced errors.New(fmt.Sprintf()) with fmt.Errorf(). According to the following blog, fmt.Errorf() is recommended for errors that require formatting, and errors.New() is recommended if the error text cannot be changed. ref: https://www.digitalocean.com/community/tutorials/how-to-add-extra-information-to-errors-in-go

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
