### PR TITLE
Bugfix: Fixed the issue where disk verification failed in check os

### DIFF
--- a/cli/cmd/check_os.go
+++ b/cli/cmd/check_os.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -131,7 +130,6 @@ func (doc *CheckOsCommand) execBladeCmd(checkExecCmd *CheckExecCmd, osAll bool) 
 	for _, execResult := range checkExecCmd.ExecResult {
 		//1.1 create os cmd
 		response = ch.Run(context.Background(), BladeBinPath, execResult.cmd)
-		var res spec.Response
 		if !response.Success {
 			execResult.result = "failed"
 			execResult.info = fmt.Sprintf("%s, exec failed! create err: %s", execResult.cmd, response.Err)
@@ -141,19 +139,8 @@ func (doc *CheckOsCommand) execBladeCmd(checkExecCmd *CheckExecCmd, osAll bool) 
 			}
 			continue
 		}
-		err := json.Unmarshal([]byte(response.Result.(string)), &res)
-		if err != nil {
-			execResult.result = "failed"
-			execResult.info = fmt.Sprintf("%s, exec failed! create err: %s", execResult.cmd, response.Result)
-			response.Err = fmt.Sprintf("[failed] %s, exec failed! create err: %s", execResult.cmd, response.Result)
-			if osAll {
-				fmt.Printf("[failed] %s, exec failed! create err: %s \n", execResult.cmd, response.Result)
-			}
-			continue
-		}
-
 		// 1.2 destroy os cmd
-		response = ch.Run(context.Background(), BladeBinPath, fmt.Sprintf("destroy %s", res.Result.(string)))
+		response = ch.Run(context.Background(), BladeBinPath, fmt.Sprintf("destroy %s", response.Result.(string)))
 		if !response.Success {
 			execResult.result = "failed"
 			execResult.info = fmt.Sprintf("%s, exec failed! destroy err: %s", execResult.cmd, response.Err)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix #941 
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

Remove redundant json parsing.

### Describe how to verify it

```
# ./blade check os
[success] cpu fullload, success! `taskset` command exists 
[success] men load, success! `mount` command exists 
[success] men load, success! `umount` command exists 
[success] network delay, success! `tc` command exists 
[success] network drop, success! `iptables` command exists 
[success] network dns, success! `set` command exists 
[success] network loss, success! `tc` command exists 
[success] network duplicate, success! `tc` command exists 
[success] network corrupt, success! `tc` command exists 
[success] network reorder, success! `tc` command exists 
[success] network occupy, success! `ss` command exists 
[success] create disk burn --read true, success! 
[success] create disk burn --write true, success! 
```

### Special notes for reviews
