### PR TITLE
Bugfix: the cri and k8s scenarios are missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ endif
 	@if [ -z "$(GOOS)" ]; then \
 		make -C $(BUILD_TARGET_CACHE)/chaosblade-exec-cri; \
 	else \
-		make -C $(BUILD_TARGET_CACHE)/chaosblade-exec-cri $(GOOS)_$(GOARCH) JVM_SPEC_PATH=$$(cd $(OUTPUT_DIR)/yaml && pwd); \
+		make -C $(BUILD_TARGET_CACHE)/chaosblade-exec-cri $(GOOS)_$(GOARCH); \
 	fi
 	@cp -R $(BUILD_TARGET_CACHE)/chaosblade-exec-cri/target/$(call get_platform_dir_name,$(GOOS),$(GOARCH))/* $(OUTPUT_DIR)/
 
@@ -426,9 +426,9 @@ else
 endif
 	@$(eval OUTPUT_DIR := $(call get_build_output_dir))
 	@if [ "$(GOOS)_$(GOARCH)" == "linux_amd64" ] || [ "$(GOOS)_$(GOARCH)" == "linux_arm64" ]; then \
-		make -C $(BUILD_TARGET_CACHE)/chaosblade-operator $(GOOS)_$(GOARCH) JVM_SPEC_PATH=$$(cd $(OUTPUT_DIR)/yaml && pwd); \
+		make -C $(BUILD_TARGET_CACHE)/chaosblade-operator $(GOOS)_$(GOARCH); \
 	else \
-		make -C $(BUILD_TARGET_CACHE)/chaosblade-operator only_yaml JVM_SPEC_PATH=$$(cd $(OUTPUT_DIR)/yaml && pwd); \
+		make -C $(BUILD_TARGET_CACHE)/chaosblade-operator only_yaml; \
 	fi; \
 	cp -R $(BUILD_TARGET_CACHE)/chaosblade-operator/$(BUILD_TARGET)/chaosblade-$(BLADE_VERSION)/* $(OUTPUT_DIR)/
 

--- a/build/image/musl/Dockerfile
+++ b/build/image/musl/Dockerfile
@@ -20,8 +20,7 @@ RUN wget http://mirrors.tuna.tsinghua.edu.cn/apache/maven/maven-3/${MAVEN_VERSIO
     && mv apache-maven-${MAVEN_VERSION} /usr/local/apache-maven-${MAVEN_VERSION}
 
 RUN apt-get update \
-    && apt-get install -y unzip openjdk-11-jdk \
-    && apt-get install upx-ucl
+    && apt-get install -y unzip  upx-ucl openjdk-21-jdk
 
 ENV CC /usr/local/musl/bin/musl-gcc
 ENV GOOS linux

--- a/cli/cmd/exp.go
+++ b/cli/cmd/exp.go
@@ -233,15 +233,14 @@ func (ec *baseExpCommandService) registerDockerExpCommands() []*modelCommand {
 
 	file = path.Join(specutil.GetYamlHome(), fmt.Sprintf("chaosblade-jvm-spec-%s.yaml", version.Ver))
 	models, err = specutil.ParseSpecsToModel(file, docker.NewExecutor())
-	if err != nil {
-		return nil
-	}
-	for idx := range models.Models {
-		model := &models.Models[idx]
-		model.ExpScope = "docker"
-		spec.AddFlagsToModelSpec(exec.GetExecInContainerFlags, model)
-		command := ec.registerExpCommand(model, dockerSpec.Name())
-		modelCommands = append(modelCommands, command)
+	if err == nil {
+		for idx := range models.Models {
+			model := &models.Models[idx]
+			model.ExpScope = "docker"
+			spec.AddFlagsToModelSpec(exec.GetExecInContainerFlags, model)
+			command := ec.registerExpCommand(model, dockerSpec.Name())
+			modelCommands = append(modelCommands, command)
+		}
 	}
 
 	dockerCmd := ec.registerExpCommand(dockerSpec, "")
@@ -277,17 +276,15 @@ func (ec *baseExpCommandService) registerK8sExpCommands() []*modelCommand {
 
 	file = path.Join(specutil.GetYamlHome(), fmt.Sprintf("chaosblade-jvm-spec-%s.yaml", version.Ver))
 	models, err = specutil.ParseSpecsToModel(file, kubernetes.NewExecutor())
-	if err != nil {
-		return nil
+	if err == nil {
+		for idx := range models.Models {
+			model := &models.Models[idx]
+			model.ExpScope = "container"
+			spec.AddFlagsToModelSpec(GetResourceFlags, model)
+			command := ec.registerExpCommand(model, k8sSpec.Name())
+			modelCommands = append(modelCommands, command)
+		}
 	}
-	for idx := range models.Models {
-		model := &models.Models[idx]
-		model.ExpScope = "container"
-		spec.AddFlagsToModelSpec(GetResourceFlags, model)
-		command := ec.registerExpCommand(model, k8sSpec.Name())
-		modelCommands = append(modelCommands, command)
-	}
-
 	k8sCmd := ec.registerExpCommand(k8sSpec, "")
 	cobraCmd := k8sCmd.CobraCmd()
 
@@ -314,17 +311,15 @@ func (ec *baseExpCommandService) registerCriExpCommands() []*modelCommand {
 
 	file = path.Join(specutil.GetYamlHome(), fmt.Sprintf("chaosblade-jvm-spec-%s.yaml", version.Ver))
 	models, err = specutil.ParseSpecsToModel(file, cri.NewExecutor())
-	if err != nil {
-		return nil
+	if err == nil {
+		for idx := range models.Models {
+			model := &models.Models[idx]
+			model.ExpScope = "cri"
+			spec.AddFlagsToModelSpec(exec.GetExecInContainerFlags, model)
+			command := ec.registerExpCommand(model, criSpec.Name())
+			modelCommands = append(modelCommands, command)
+		}
 	}
-	for idx := range models.Models {
-		model := &models.Models[idx]
-		model.ExpScope = "cri"
-		spec.AddFlagsToModelSpec(exec.GetExecInContainerFlags, model)
-		command := ec.registerExpCommand(model, criSpec.Name())
-		modelCommands = append(modelCommands, command)
-	}
-
 	criCmd := ec.registerExpCommand(criSpec, "")
 	cobraCmd := criCmd.CobraCmd()
 	for _, child := range modelCommands {

--- a/version/version_info.go
+++ b/version/version_info.go
@@ -12,13 +12,13 @@ var (
 	GitTag = "v1.7.4"
 	
 	// GitCommit Git提交哈希
-	GitCommit = "6456629"
+	GitCommit = "bd2849c"
 	
 	// GitBranch Git分支
-	GitBranch = "bugfix-cplus-spec-yaml"
+	GitBranch = "bugfix-1144"
 	
 	// BuildTime 构建时间
-	BuildTime = "2025-09-09 02:35:22 UTC"
+	BuildTime = "2025-09-10 02:40:46 UTC"
 	
 	// BuildTimeParsed 解析后的构建时间
 	BuildTimeParsed, _ = time.Parse("2006-01-02 15:04:05 UTC", BuildTime)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

Fix #1144 

### Describe how you did it
When an error occurs when reading the jvm spec file, execute the cri and k8s commands normally.

### Describe how to verify it
Delete `chaosblade-jvm-spec-xxx.yaml` file  and execute `blade c  cri-h` command:
```
# ll yaml/
total 132
-rwxr-xr-x 1 502 games 58330 Sep 10 10:07 chaosblade-cri-spec-1.7.5.yaml
-rwxr-xr-x 1 502 games 71555 Sep 10 10:07 chaosblade-os-spec-1.7.5.yaml


# ./blade c cri -h
CRI experiment, for example remove container. If container-runtime is containerd, the container-id shoud be full id.

Usage:
  blade create cri [flags]
  blade create cri [command]

Available Commands:
  container   Execute a container experiment
  cpu         Cpu experiment
  disk        Disk experiment
  file        File experiment
  mem         Mem experiment
  network     Network experiment
  process     Process experiment

Flags:
  -h, --help   help for cri

Global Flags:
  -a, --async             whether to create asynchronously, default is false
  -d, --debug             Set client to DEBUG mode
  -e, --endpoint string   the create result reporting address. It takes effect only when the async value is true and the value is not empty
  -n, --nohup             used to internal async create, no need to config
      --uid string        Set Uid for the experiment, adapt to docker and cri

Use "blade create cri [command] --help" for more information about a command.
```

### Special notes for reviews
