### PR TITLE
Bugfix: Solve the problem of command failure in container scenario

### DIFF
--- a/nsexec.c
+++ b/nsexec.c
@@ -10,7 +10,9 @@
 #include <getopt.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 #include <sys/stat.h>
 #include <sys/syscall.h>
 
@@ -51,7 +53,8 @@ int main(int argc, char *argv[]) {
     int stop = 0;
     int opt;
     int option_index = 0;
-    char *string = "st:mpuni";
+    char *string = "st:mpuni:";
+    int use_absolute_path = 0;
 
     int ipcns = 0;
     int utsns = 0;
@@ -89,39 +92,62 @@ int main(int argc, char *argv[]) {
 
     // check target pid
     if (target <= 0) {
-        fprintf(stderr, "%s is not a valid process ID\n", target);
+        fprintf(stderr, "%d is not a valid process ID\n", target);
         return 1;
     }
 
     // pause
     if(stop) {
+#ifdef __linux__
             char *pe = "pause";
             prctl(PR_SET_NAME, pe);
+#endif
             signal(SIGCONT,sig);
             pause();
+#ifdef __linux__
             char *nc = "nsexec";
             prctl(PR_SET_NAME, nc);
+#endif
     }
 
+    // 保存原始环境变量
+    char *original_path = getenv("PATH");
+    char *original_home = getenv("HOME");
+    
     // enter namespace
     if(ipcns) {
-        enter_ns(target, "ipc");
+        if (enter_ns(target, "ipc") < 0) {
+            fprintf(stderr, "Failed to enter IPC namespace\n");
+            return 1;
+        }
     }
 
     if(utsns) {
-        enter_ns(target, "uts");
+        if (enter_ns(target, "uts") < 0) {
+            fprintf(stderr, "Failed to enter UTS namespace\n");
+            return 1;
+        }
     }
 
     if(netns) {
-        enter_ns(target, "net");
+        if (enter_ns(target, "net") < 0) {
+            fprintf(stderr, "Failed to enter NET namespace\n");
+            return 1;
+        }
     }
 
     if(pidns) {
-        enter_ns(target, "pid");
+        if (enter_ns(target, "pid") < 0) {
+            fprintf(stderr, "Failed to enter PID namespace\n");
+            return 1;
+        }
     }
 
     if(mntns) {
-        enter_ns(target, "mnt");
+        if (enter_ns(target, "mnt") < 0) {
+            fprintf(stderr, "Failed to enter MNT namespace\n");
+            return 1;
+        }
     }
 
     // fork exec
@@ -131,6 +157,64 @@ int main(int argc, char *argv[]) {
     if((pid = fork())<0) {
         status = -1;
     } else if(pid == 0){
+        // 如果PATH为空或无效，尝试恢复原始PATH
+        char *current_path = getenv("PATH");
+        if (current_path == NULL || strlen(current_path) == 0) {
+            if (original_path != NULL) {
+                setenv("PATH", original_path, 1);
+            }
+        }
+        
+        // 确保PATH包含/bin路径
+        current_path = getenv("PATH");
+        if (current_path != NULL) {
+            // 检查PATH中是否包含独立的/bin路径（不是/usr/bin等）
+            char *path_copy = strdup(current_path);
+            char *dir = strtok(path_copy, ":");
+            int has_bin = 0;
+            while (dir != NULL) {
+                if (strcmp(dir, "/bin") == 0) {
+                    has_bin = 1;
+                    break;
+                }
+                dir = strtok(NULL, ":");
+            }
+            free(path_copy);
+            
+            if (!has_bin) {
+                char new_path[2048];
+                snprintf(new_path, sizeof(new_path), "%s:/bin", current_path);
+                setenv("PATH", new_path, 1);
+            }
+        }
+        
+        // 检查命令是否存在和可执行
+        if (access(argv[optind], F_OK) != 0) {
+            // 尝试在PATH中查找命令
+            char *path = getenv("PATH");
+            if (path != NULL) {
+                char *path_copy = strdup(path);
+                char *dir = strtok(path_copy, ":");
+                char found_path[1024] = {0};
+                
+                while (dir != NULL) {
+                    char full_path[1024];
+                    snprintf(full_path, sizeof(full_path), "%s/%s", dir, argv[optind]);
+                    if (access(full_path, F_OK) == 0) {
+                        strncpy(found_path, full_path, sizeof(found_path) - 1);
+                        break;
+                    }
+                    dir = strtok(NULL, ":");
+                }
+                free(path_copy);
+                
+                // 如果找到了命令，更新argv[optind]
+                if (strlen(found_path) > 0) {
+                    argv[optind] = found_path;
+                }
+            }
+        }
+        
         // args
         int i,j=0;
         char *args[256] = {NULL};
@@ -138,6 +222,9 @@ int main(int argc, char *argv[]) {
             args[j] = argv[i];
         }
         execvp(argv[optind], args);
+        
+        // 如果execvp失败，输出错误信息
+        fprintf(stderr, "execvp failed: %s\n", strerror(errno));
         _exit(127);
     } else {
         while(waitpid(pid, &status, 0) < 0){
@@ -147,7 +234,20 @@ int main(int argc, char *argv[]) {
             }
         }
         if(WIFEXITED(status)){
-            exit(WEXITSTATUS(status));
+            // 正确传递子进程的退出状态码
+            int exit_code = WEXITSTATUS(status);
+            if(exit_code != 0) {
+                // 如果子进程非正常退出，输出错误信息
+                fprintf(stderr, "Child process exited with code %d\n", exit_code);
+            }
+            exit(exit_code);
+        } else if(WIFSIGNALED(status)){
+            int signal_num = WTERMSIG(status);
+            fprintf(stderr, "Child process terminated by signal %d\n", signal_num);
+            exit(128 + signal_num);
+        } else {
+            fprintf(stderr, "Child process terminated abnormally\n");
+            exit(1);
         }
     }
     return 0;


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

Fix #1146 

### Describe how you did it

1. Add `/bin` to PATH.
2. Optimize error handling.

### Describe how to verify it
```
./blade c cri mem load --container-id 0cc6f9f157b182e1ed9a1a7b5110f8760bc2882dc203dc627313aee522e68eba --container-runtime containerd --mem-percent 80 --mode cache -d
{"code":200,"success":true,"result":"7542c2e8a6a0ae05"}
```
The log:
```
time="2025-09-10 15:18:02.282408363 CST" level=info msg="mode: create, target: mem, action: load, flags map[avoid-being-killed: cgroup-root:/sys/fs/cgroup channel:nsexec debug:true include-buffer-cache: mem-percent:80 mode:cache ns_mnt:true ns_net:false ns_pid:true ns_target:2023202 rate: reserve: uid:7542c2e8a6a0ae05]" location="/Users/changjun/Codespace/ChaosBladeProjects/chaosblade/target/cache/chaosblade-exec-os/main.go:123" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.282489071 CST" level=debug msg="Command: /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c \"command -v dd\"" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:77" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.284574783 CST" level=debug msg="Command Result, output: /bin/dd\n, err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:84" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.284600022 CST" level=debug msg="Command: /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c \"command -v mount\"" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:77" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.286565767 CST" level=debug msg="Command Result, output: /bin/mount\n, err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:84" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.286585683 CST" level=debug msg="Command: /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c \"command -v umount\"" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:77" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.28840044 CST" level=debug msg="Command Result, output: /bin/umount\n, err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:84" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.288422634 CST" level=debug msg="Command: /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c \"mkdir -p /root/chaosblade-1.7.5-linux_amd64/bin/burnmem_tmpfs\"" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:77" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.290492939 CST" level=debug msg="Command Result, output: , err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:84" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.290518755 CST" level=debug msg="Command: /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c \"mount -t tmpfs -o size=100% chaos_burn /root/chaosblade-1.7.5-linux_amd64/bin/burnmem_tmpfs\"" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:77" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:02.29262291 CST" level=debug msg="Command Result, output: , err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.4/channel/nsexec.go:84" uid=7542c2e8a6a0ae05
time="2025-09-10 15:18:03.292698545 CST" level=debug msg="get mem useage by cgroup, root path: /sys/fs/cgroup" location="/Users/changjun/Codespace/ChaosBladeProjects/chaosblade/target/cache/chaosblade-exec-os/exec/mem/mem_linux.go:47" uid=7542c2e8a6a0ae05
```
Mount result:
```
# /root/chaosblade-1.7.5-linux_amd64/bin/nsexec -t 2023202 -p -m -- /bin/sh -c "mount | grep chaos"
tmpfs on /opt/chaosblade/chaosblade.dat type tmpfs (rw,mode=755)
chaos_burn on /root/chaosblade-1.7.5-linux_amd64/bin/burnmem_tmpfs type tmpfs (rw,relatime,size=15563092k)
```


### Special notes for reviews
