### PR TITLE
Bugfix: Fixed the issue where the sudo command does not exist in Java…

### DIFF
--- a/nsexec.c
+++ b/nsexec.c
@@ -234,20 +234,7 @@ int main(int argc, char *argv[]) {
             }
         }
         if(WIFEXITED(status)){
-            // 正确传递子进程的退出状态码
-            int exit_code = WEXITSTATUS(status);
-            if(exit_code != 0) {
-                // 如果子进程非正常退出，输出错误信息
-                fprintf(stderr, "Child process exited with code %d\n", exit_code);
-            }
-            exit(exit_code);
-        } else if(WIFSIGNALED(status)){
-            int signal_num = WTERMSIG(status);
-            fprintf(stderr, "Child process terminated by signal %d\n", signal_num);
-            exit(128 + signal_num);
-        } else {
-            fprintf(stderr, "Child process terminated abnormally\n");
-            exit(1);
+            exit(WEXITSTATUS(status));
         }
     }
     return 0;


### PR DESCRIPTION
… failure scenarios

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

cmd exec failed, err: /bin/sh: sudo: command not found\\n exit status 127

### Does this pull request fix one issue?

Fix the error when the sudo command does not exist in the issue #1129 



### Describe how you did it

* If sudo is available: Use sudo -u username java ...
* If sudo is not available: Use su - username -c 'java ...' as a fallback.

### Describe how to verify it
Before the repair, executing the `./blade c cri jvm cpufullload ...` command reported an error:
```
cmd exec failed, err: /bin/sh: sudo: command not found\\n exit status 127
```

After the repair:
```
./blade c cri jvm cpufullload --process petstore-cart --cpu-count 2 --container-id a1541bd4feb26053120e594d49f75ead311316bdaa861574f21ba5f56cef24af --container-runtime containerd --chaosblade-release /root/chaosblade-1.7.5-linux_amd64.tar.gz --chaosblade-override -d

{"code":200,"success":true,"result":"d677f6dd22af6634"}

```

The relevant logs are as follows: 
```
time="2025-09-10 11:24:03.195205056 UTC" level=debug msg="Command:  which sudo" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.5-0.20250902032330-12bd479355fe/channel/local_unixs.go:269" uid=d677f6dd22af6634
time="2025-09-10 11:24:03.195933026 UTC" level=debug msg="Command Result, output: /bin/sh: which: command not found\n, err: exit status 127" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.5-0.20250902032330-12bd479355fe/channel/local_unixs.go:274" uid=d677f6dd22af6634
time="2025-09-10 11:24:03.195948971 UTC" level=info msg="sudo command not available, using su command instead" location="/Users/changjun/Codespace/ChaosBladeProjects/chaosblade/exec/jvm/sandbox.go:141" uid=d677f6dd22af6634
time="2025-09-10 11:24:03.195958892 UTC" level=debug msg="Command:  su - admin -c 'java/bin/java -Xms128M -Xmx128M -Xnoclassgc -ea -Xbootclasspath/a:/opt/chaosblade/lib/sandbox/tools.jar -jar /opt/chaosblade/lib/sandbox/lib/sandbox-core.jar 1 \"/opt/chaosblade/lib/sandbox/lib/sandbox-agent.jar\" \"home=/opt/chaosblade/lib/sandbox;token=351782287229;server.ip=127.0.0.1;server.port=36437;namespace=chaosblade\"'" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.5-0.20250902032330-12bd479355fe/channel/local_unixs.go:269" uid=d677f6dd22af6634
time="2025-09-10 11:24:04.335483042 UTC" level=debug msg="Command Result, output: , err: <nil>" location="/Users/changjun/go/pkg/mod/github.com/chaosblade-io/chaosblade-spec-go@v1.7.5-0.20250902032330-12bd479355fe/channel/local_unixs.go:274" uid=d677f6dd22af6634
```
The execution result is as follows:

<img width="1260" height="492" alt="image" src="https://github.com/user-attachments/assets/62707cd6-84be-4814-96df-437eb60ba0a6" />



### Special notes for reviews
