### PR TITLE
feat: Supports accessing the cluster through kubectl-proxy

### DIFF
--- a/cli/cmd/query_k8s.go
+++ b/cli/cmd/query_k8s.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/chaosblade-io/chaosblade-spec-go/spec"
 
 	"github.com/spf13/cobra"
@@ -29,6 +30,8 @@ import (
 type QueryK8sCommand struct {
 	baseCommand
 	kubeconfig string
+	proxyURL   string
+	token      string
 }
 
 func (q *QueryK8sCommand) Init() {
@@ -43,16 +46,21 @@ func (q *QueryK8sCommand) Init() {
 		Example: q.queryK8sExample(),
 	}
 	q.command.Flags().StringVarP(&q.kubeconfig, "kubeconfig", "k", "", "the kubeconfig path")
+	q.command.Flags().StringVar(&q.proxyURL, "kubectl-proxy", "", "Kubectl proxy URL for accessing Kubernetes API, e.g., http://localhost:8001")
+	q.command.Flags().StringVar(&q.token, "token", "", "Bearer token for Kubernetes API authentication")
 }
 
 func (q *QueryK8sCommand) queryK8sExample() string {
-	return `blade query k8s create 29c3f9dab4abbc79`
+	return `blade query k8s create 29c3f9dab4abbc79
+
+# 使用 kubectl proxy 查询状态
+blade query k8s create 29c3f9dab4abbc79 --kubectl-proxy http://localhost:8001`
 }
 
 // queryK8sExpStatus by uid
 func (q *QueryK8sCommand) queryK8sExpStatus(command *cobra.Command, cmd, uid string) error {
 	ctx := context.WithValue(context.Background(), spec.Uid, uid)
-	response, _ := kubernetes.QueryStatus(ctx, cmd, q.kubeconfig)
+	response, _ := kubernetes.QueryStatus(ctx, cmd, q.kubeconfig, q.proxyURL, q.token)
 	if response.Success {
 		command.Println(response.Print())
 	} else {

--- a/exec/kubernetes/spec.go
+++ b/exec/kubernetes/spec.go
@@ -34,6 +34,16 @@ var WaitingTimeFlag = &spec.ExpFlag{
 	Desc: "Waiting time for invoking, default value is 20s",
 }
 
+var KubectlProxyFlag = &spec.ExpFlag{
+	Name: "kubectl-proxy",
+	Desc: "Kubectl proxy URL for accessing Kubernetes API, e.g., http://localhost:8001",
+}
+
+var TokenFlag = &spec.ExpFlag{
+	Name: "token",
+	Desc: "Bearer token for Kubernetes API authentication",
+}
+
 //var log = logf.Log.WithName("Kubernetes")
 
 func NewCommandModelSpec() spec.ExpModelCommandSpec {
@@ -41,7 +51,7 @@ func NewCommandModelSpec() spec.ExpModelCommandSpec {
 		spec.BaseExpModelCommandSpec{
 			ExpActions: []spec.ExpActionCommandSpec{},
 			ExpFlags: []spec.ExpFlagSpec{
-				KubeConfigFlag, WaitingTimeFlag,
+				KubeConfigFlag, WaitingTimeFlag, KubectlProxyFlag, TokenFlag,
 			},
 		},
 	}
@@ -60,5 +70,9 @@ func (*CommandModelSpec) LongDesc() string {
 }
 
 func (*CommandModelSpec) Example() string {
-	return "blade create k8s node-cpu fullload --names cn-hangzhou.192.168.0.205 --cpu-percent 80 --kubeconfig ~/.kube/config"
+	return `blade create k8s node-cpu fullload --names cn-hangzhou.192.168.0.205 --cpu-percent 80 --kubeconfig ~/.kube/config
+
+# 使用 kubectl proxy 和 token 认证
+# 首先启动 kubectl proxy: kubectl proxy --port=8080
+blade create k8s node-cpu fullload --names cn-hangzhou.192.168.0.205 --cpu-percent 80 --kubectl-proxy http://localhost:8080 --token your-token-here`
 }

--- a/version/version_info.go
+++ b/version/version_info.go
@@ -7,19 +7,19 @@ import "time"
 var (
 	// Ver 版本号
 	Ver = "1.7.5"
-
+	
 	// GitTag Git标签
 	GitTag = "v1.7.5"
-
+	
 	// GitCommit Git提交哈希
-	GitCommit = "145fdfd"
-
+	GitCommit = "6d290d7"
+	
 	// GitBranch Git分支
-	GitBranch = "master"
-
+	GitBranch = "feature-1184"
+	
 	// BuildTime 构建时间
-	BuildTime = "2025-09-14 10:38:58 UTC"
-
+	BuildTime = "2025-09-16 11:54:43 UTC"
+	
 	// BuildTimeParsed 解析后的构建时间
 	BuildTimeParsed, _ = time.Parse("2006-01-02 15:04:05 UTC", BuildTime)
 )
@@ -27,7 +27,7 @@ var (
 // GetVersionInfo 获取完整的版本信息
 func GetVersionInfo() map[string]string {
 	return map[string]string{
-		"version":   Ver,
+		"version":    Ver,
 		"gitTag":    GitTag,
 		"gitCommit": GitCommit,
 		"gitBranch": GitBranch,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

#1184 


### Describe how you did it
New parameters: `--kubectl-proxy` and `--token`.

If both --kubectl-proxy and --token are provided: token authentication is used directly, without relying on kubeconfig.

If both --kubectl-proxy and --kubeconfig are provided: authentication information is obtained from the kubeconfig file, and then access is performed through a proxy.

If only --kubectl-proxy is provided: authentication information is attempted from the default kubeconfig location, and if that fails, a simple proxy configuration is used.

Use case:

```
./blade c k8s pod-file append --filepath /opt/l.log --content "hello" --names chaosblade-tool-rw4kn --namespace chaosblade --kubectl-proxy "https://cloudshell.a-workbench.com:80"  --token xxxx 
```

### Describe how to verify it
```
# ps -ef | grep kubectl
    1 root      0:00 kubectl --port 8080 proxy --server https://cloudshell.a-workbench.com:80 --token h86bxxxx --disable-filter=true

# ./blade c k8s pod-file append --filepath /opt/l.log --content "hello" --names chaosblade-tool-rw4kn --namespace chaosblade --kubectl-proxy "https://cloudshell.a-workbench.com:80" --token h86bxxxx 

{"code":200,"success":true,"result":"e1a66116feafee57"}

# k exec -it -n chaosblade chaosblade-tool-rw4kn -- cat /opt/l.log
hello
```


### Special notes for reviews
