### PR TITLE
fix: duplicate column name pid

### DIFF
--- a/data/preparation.go
+++ b/data/preparation.go
@@ -122,12 +122,19 @@ func (s *Source) CheckAndInitPreTable() {
 		//os.Exit(1)
 	}
 	if exists {
-		// execute alter sql if exists
-		err := s.AlterPreparationTable(addPidColumn)
+		// check if pid column exists before adding it
+		pidColumnExists, err := s.ColumnExists("preparation", "pid")
 		if err != nil {
 			log.Fatalf(ctx, err.Error())
-			//log.Error(err, "AlterPreparationTable err", "addPidColumn", addPidColumn)
-			//os.Exit(1)
+		}
+		if !pidColumnExists {
+			// execute alter sql if column doesn't exist
+			err := s.AlterPreparationTable(addPidColumn)
+			if err != nil {
+				log.Fatalf(ctx, err.Error())
+				//log.Error(err, "AlterPreparationTable err", "addPidColumn", addPidColumn)
+				//os.Exit(1)
+			}
 		}
 	} else {
 		// execute create table

--- a/data/source.go
+++ b/data/source.go
@@ -105,3 +105,29 @@ func (s *Source) UpdateUserVersion(version int) error {
 func UpperFirst(str string) string {
 	return string(unicode.ToUpper(rune(str[0]))) + str[1:]
 }
+
+// ColumnExists checks if a column exists in the specified table
+func (s *Source) ColumnExists(tableName, columnName string) (bool, error) {
+	query := `SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`
+	stmt, err := s.DB.Prepare(query)
+	if err != nil {
+		return false, fmt.Errorf("prepare column exists query err, %s", err)
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(tableName, columnName)
+	if err != nil {
+		return false, fmt.Errorf("query column exists err, %s", err)
+	}
+	defer rows.Close()
+
+	var count int
+	if rows.Next() {
+		err = rows.Scan(&count)
+		if err != nil {
+			return false, fmt.Errorf("scan column count err, %s", err)
+		}
+	}
+
+	return count > 0, nil
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it


### Does this pull request fix one issue?

Fix #1108 
### Describe how you did it
Added column existence check: In the CheckAndInitPreTable() function, a check is added to check whether the pid column exists.
Implemented the ColumnExists method: Added the ColumnExists method in source.go to check whether a column exists in a specified table.
Optimized the migration logic: ALTER TABLE statements are executed only if the column does not exist.

### Describe how to verify it


### Special notes for reviews
