### PR TITLE
feat: Support specifying chaosblade data file path

### DIFF
--- a/data/source_test.go
+++ b/data/source_test.go
@@ -1,0 +1,222 @@
+/*
+ * Copyright 1999-2020 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+)
+
+func TestGetDataFilePath(t *testing.T) {
+	// 保存原始环境变量
+	originalEnv := os.Getenv("CHAOSBLADE_DATAFILE_PATH")
+	defer func() {
+		// 恢复原始环境变量
+		if originalEnv == "" {
+			os.Unsetenv("CHAOSBLADE_DATAFILE_PATH")
+		} else {
+			os.Setenv("CHAOSBLADE_DATAFILE_PATH", originalEnv)
+		}
+	}()
+
+	tests := []struct {
+		name           string
+		envValue       string
+		setupFunc      func() error
+		cleanupFunc    func() error
+		expectedPrefix string
+		expectedSuffix string
+		expectError    bool
+	}{
+		{
+			name:           "no environment variable",
+			envValue:       "",
+			expectedPrefix: util.GetProgramPath(),
+			expectedSuffix: dataFile,
+		},
+		{
+			name:     "existing directory",
+			envValue: "/tmp/test_existing_dir",
+			setupFunc: func() error {
+				return os.MkdirAll("/tmp/test_existing_dir", 0755)
+			},
+			cleanupFunc: func() error {
+				return os.RemoveAll("/tmp/test_existing_dir")
+			},
+			expectedPrefix: "/tmp/test_existing_dir",
+			expectedSuffix: dataFile,
+		},
+		{
+			name:     "non-existing directory",
+			envValue: "/tmp/test_nonexistent_dir",
+			cleanupFunc: func() error {
+				return os.RemoveAll("/tmp/test_nonexistent_dir")
+			},
+			expectedPrefix: "/tmp/test_nonexistent_dir",
+			expectedSuffix: dataFile,
+		},
+		{
+			name:     "existing file",
+			envValue: "/tmp/test_existing_file.db",
+			setupFunc: func() error {
+				file, err := os.Create("/tmp/test_existing_file.db")
+				if err != nil {
+					return err
+				}
+				return file.Close()
+			},
+			cleanupFunc: func() error {
+				return os.Remove("/tmp/test_existing_file.db")
+			},
+			expectedPrefix: "/tmp/test_existing_file.db",
+			expectedSuffix: "",
+		},
+		{
+			name:     "non-existing file",
+			envValue: "/tmp/test_nonexistent_file.db",
+			cleanupFunc: func() error {
+				return os.Remove("/tmp/test_nonexistent_file.db")
+			},
+			expectedPrefix: "/tmp/test_nonexistent_file.db",
+			expectedSuffix: "",
+		},
+		{
+			name:     "non-existing file with non-existing parent directory",
+			envValue: "/tmp/test_deep/nested/path/file.db",
+			cleanupFunc: func() error {
+				return os.RemoveAll("/tmp/test_deep")
+			},
+			expectedPrefix: "/tmp/test_deep/nested/path/file.db",
+			expectedSuffix: "",
+		},
+		{
+			name:     "directory with extension (treated as file)",
+			envValue: "/tmp/test_dir_with_ext.dat",
+			cleanupFunc: func() error {
+				return os.Remove("/tmp/test_dir_with_ext.dat")
+			},
+			expectedPrefix: "/tmp/test_dir_with_ext.dat",
+			expectedSuffix: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 设置环境变量
+			if tt.envValue == "" {
+				os.Unsetenv("CHAOSBLADE_DATAFILE_PATH")
+			} else {
+				os.Setenv("CHAOSBLADE_DATAFILE_PATH", tt.envValue)
+			}
+
+			// 执行设置函数
+			if tt.setupFunc != nil {
+				if err := tt.setupFunc(); err != nil {
+					t.Fatalf("Setup failed: %v", err)
+				}
+			}
+
+			// 执行清理函数
+			if tt.cleanupFunc != nil {
+				defer func() {
+					if err := tt.cleanupFunc(); err != nil {
+						t.Logf("Cleanup failed: %v", err)
+					}
+				}()
+			}
+
+			// 调用被测试的函数
+			result := GetDataFilePath()
+
+			// 验证结果
+			if tt.expectedSuffix != "" {
+				expected := filepath.Join(tt.expectedPrefix, tt.expectedSuffix)
+				if result != expected {
+					t.Errorf("GetDataFilePath() = %v, want %v", result, expected)
+				}
+			} else {
+				if result != tt.expectedPrefix {
+					t.Errorf("GetDataFilePath() = %v, want %v", result, tt.expectedPrefix)
+				}
+			}
+
+			// 验证路径是否实际存在（对于目录和文件路径）
+			if tt.expectedSuffix != "" {
+				// 对于目录路径，检查目录是否存在
+				if _, err := os.Stat(filepath.Dir(result)); err != nil {
+					t.Errorf("Expected directory does not exist: %v", err)
+				}
+			} else if tt.envValue != "" {
+				// 对于文件路径，检查父目录是否存在
+				if _, err := os.Stat(filepath.Dir(result)); err != nil {
+					t.Errorf("Expected parent directory does not exist: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetDataFilePathWithPermissionError(t *testing.T) {
+	// 保存原始环境变量
+	originalEnv := os.Getenv("CHAOSBLADE_DATAFILE_PATH")
+	defer func() {
+		// 恢复原始环境变量
+		if originalEnv == "" {
+			os.Unsetenv("CHAOSBLADE_DATAFILE_PATH")
+		} else {
+			os.Setenv("CHAOSBLADE_DATAFILE_PATH", originalEnv)
+		}
+	}()
+
+	// 测试权限不足的情况（在大多数系统上，/root 目录通常没有写权限）
+	os.Setenv("CHAOSBLADE_DATAFILE_PATH", "/root/test_no_permission")
+
+	// 调用函数，应该回退到默认路径
+	result := GetDataFilePath()
+	expected := filepath.Join(util.GetProgramPath(), dataFile)
+
+	if result != expected {
+		t.Errorf("GetDataFilePath() with permission error = %v, want %v", result, expected)
+	}
+}
+
+func TestGetDataFilePathWithInvalidPath(t *testing.T) {
+	// 保存原始环境变量
+	originalEnv := os.Getenv("CHAOSBLADE_DATAFILE_PATH")
+	defer func() {
+		// 恢复原始环境变量
+		if originalEnv == "" {
+			os.Unsetenv("CHAOSBLADE_DATAFILE_PATH")
+		} else {
+			os.Setenv("CHAOSBLADE_DATAFILE_PATH", originalEnv)
+		}
+	}()
+
+	// 测试无效路径的情况（使用一个不存在的设备路径）
+	os.Setenv("CHAOSBLADE_DATAFILE_PATH", "/dev/null/invalid")
+
+	// 调用函数，应该回退到默认路径
+	result := GetDataFilePath()
+	expected := filepath.Join(util.GetProgramPath(), dataFile)
+
+	if result != expected {
+		t.Errorf("GetDataFilePath() with invalid path = %v, want %v", result, expected)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/chaosblade-io/chaosblade-exec-cri v1.7.5
 	github.com/chaosblade-io/chaosblade-exec-middleware v1.7.5
 	github.com/chaosblade-io/chaosblade-exec-os v1.7.5
-	github.com/chaosblade-io/chaosblade-operator v1.7.5
+	github.com/chaosblade-io/chaosblade-operator v1.7.6-0.20250918100041-80377c5f1d0f
 	github.com/chaosblade-io/chaosblade-spec-go v1.7.5
 	github.com/glebarez/sqlite v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5-0.20201029120751-42e21c7531a3

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/chaosblade-io/chaosblade-exec-middleware v1.7.5 h1://NZAvAyV0zQg5Zi/R
 github.com/chaosblade-io/chaosblade-exec-middleware v1.7.5/go.mod h1:x8HEXMux6qrtfF3c/WyX7OnNrMkN3GFr/S9kjHVpg2M=
 github.com/chaosblade-io/chaosblade-exec-os v1.7.5 h1:86QqPdi22QguAExxO3obJrK6ERgqktMAZNekSIid7rw=
 github.com/chaosblade-io/chaosblade-exec-os v1.7.5/go.mod h1:KNr5x3ayQL6JxEheYzt45kJvfYn8k8PyphtBZYT6+o8=
-github.com/chaosblade-io/chaosblade-operator v1.7.5 h1:hGzy/aebExb7pRYBaXhDQ2Jh2Vv8vB0mul1JzQ8YnhI=
-github.com/chaosblade-io/chaosblade-operator v1.7.5/go.mod h1:e03EZtZPG0xjLGdAXzdbCRDyqDGYUC+VftAVnxCxZ0k=
+github.com/chaosblade-io/chaosblade-operator v1.7.6-0.20250918100041-80377c5f1d0f h1:U/xO90ESvgrpf3WLkzEMK876d2mAFuSs4/5HUA7lFgA=
+github.com/chaosblade-io/chaosblade-operator v1.7.6-0.20250918100041-80377c5f1d0f/go.mod h1:e03EZtZPG0xjLGdAXzdbCRDyqDGYUC+VftAVnxCxZ0k=
 github.com/chaosblade-io/chaosblade-spec-go v1.7.5 h1:wt+N/Kzxc9kyyKnacEfSLEPUT6dzH+TLonq/tlN1pic=
 github.com/chaosblade-io/chaosblade-spec-go v1.7.5/go.mod h1:QrsUvbhnSmI7SjsKKdNM+F8MnkEE9iIZg2xV425nKsY=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Resolves #1039 

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
Added the getDataFilePath() function:
Preferentially reads the path from the CHAOSBLADE_DATAFILE_PATH environment variable.
If the environment variable is not set, the existing logic (util.GetProgramPath() + dataFile) is used.
If the path specified by the environment variable exists and is a directory, dataFile is placed in that directory.
If the path specified by the environment variable exists and is a file, the file path is used directly.
If the path specified by the environment variable does not exist, it is treated as a directory and the directory is automatically created.

### Describe how to verify it
```
# export CHAOSBLADE_DATAFILE_PATH="/Users/changjun/.chaosblade/chaosblade.db"
# ./blade v
ChaosBlade Version Information:
==============================
Version:     1.8.0
Git Tag:     v1.7.5
Git Commit:  95e1799
Git Branch:  feature-1039
Build Time:  Fri Sep 19 14:41:09 CST 2025
Release:     Yes (Production)
==============================

# ll
total 68864
drwxr-xr-x  4 changjun  staff   128B  9 19 14:41 bin
-rwxr-xr-x@ 1 changjun  staff    34M  9 19 14:41 blade
drwxr-xr-x  2 changjun  staff    64B  9 19 14:41 lib
drwxr-xr-x@ 2 changjun  staff    64B  9 19 14:42 logs
drwxr-xr-x  3 changjun  staff    96B  9 19 14:41 yaml

# ll ~/.chaosblade
total 96
-rw-r--r--@ 1 changjun  staff    48K  9 19 14:42 chaosblade.db

#  ./blade c cpu fullload --cpu-percent 10
{"code":200,"success":true,"result":"fa23d310fa834e84"}

# ll ~/.chaosblade
total 96
-rw-r--r--@ 1 changjun  staff    48K  9 19 14:42 chaosblade.db

#  ./blade s --type c
{
	"code": 200,
	"success": true,
	"result": [
		{
			"Uid": "fa23d310fa834e84",
			"Command": "cpu",
			"SubCommand": "fullload",
			"Flag": " --cpu-percent=10",
			"Status": "Success",
			"Error": "",
			"CreateTime": "2025-09-19T14:42:32.414126+08:00",
			"UpdateTime": "2025-09-19T14:42:32.525448+08:00"
		}
	]
}
```

### Special notes for reviews
