### PR TITLE
fix(tui): add hysteresis gate to suppress ±1 chrome oscillation on Linux

### DIFF
--- a/blade-ai/tui/src/components/MainContent.test.ts
+++ b/blade-ai/tui/src/components/MainContent.test.ts
@@ -133,3 +133,41 @@ describe("acceptChromeMeasurement", () => {
     expect(acceptChromeMeasurement(8, 10)).toBeNull();
   });
 });
+
+describe("acceptChromeMeasurement — hysteresis (issue #1301)", () => {
+  it("suppresses ±1 oscillation when prev is provided", () => {
+    // prev=20, measured=21 → keep 20 (not 21)
+    expect(acceptChromeMeasurement(21, 80, 20)).toBe(20);
+    // prev=20, measured=19 → keep 20 (not 19)
+    expect(acceptChromeMeasurement(19, 80, 20)).toBe(20);
+    // prev=20, measured=20 → keep 20 (exact match)
+    expect(acceptChromeMeasurement(20, 80, 20)).toBe(20);
+  });
+
+  it("accepts jumps > 1 row even with prev", () => {
+    // Real layout change: chrome grows from 20 to 25
+    expect(acceptChromeMeasurement(25, 80, 20)).toBe(25);
+    // Real layout change: chrome shrinks from 20 to 15
+    expect(acceptChromeMeasurement(15, 80, 20)).toBe(15);
+    // Boundary: exactly ±2 should pass through
+    expect(acceptChromeMeasurement(22, 80, 20)).toBe(22);
+    expect(acceptChromeMeasurement(18, 80, 20)).toBe(18);
+  });
+
+  it("ignores prev when it is undefined (backward compatibility)", () => {
+    // No prev → behaves exactly as before
+    expect(acceptChromeMeasurement(20, 80)).toBe(20);
+    expect(acceptChromeMeasurement(21, 80)).toBe(21);
+  });
+
+  it("hysteresis does not bypass other guards", () => {
+    // NaN still rejected even with prev
+    expect(acceptChromeMeasurement(Number.NaN, 80, 20)).toBeNull();
+    // Below 5 still rejected
+    expect(acceptChromeMeasurement(3, 80, 20)).toBeNull();
+    // Above cap still rejected
+    expect(acceptChromeMeasurement(36, 80, 20)).toBeNull();
+    // Infinity still rejected
+    expect(acceptChromeMeasurement(Number.POSITIVE_INFINITY, 80, 20)).toBeNull();
+  });
+});

--- a/blade-ai/tui/src/components/MainContent.tsx
+++ b/blade-ai/tui/src/components/MainContent.tsx
@@ -189,10 +189,21 @@ export function chromeMeasurementCap(rows: number): number {
 export function acceptChromeMeasurement(
   measured: number,
   rows: number,
+  prev?: number,
 ): number | null {
   if (!Number.isFinite(measured)) return null;
   if (measured < 5) return null;
   if (measured > chromeMeasurementCap(rows)) return null;
+  // Hysteresis: suppress ±1 oscillation noise.
+  // On Linux terminals (no DEC 2026 sync), Yoga integer rounding can
+  // cause measureElement to alternate between N and N±1 across renders,
+  // creating a visible flicker feedback loop. When the new measurement
+  // differs from the previously accepted value by at most 1 row, treat
+  // it as layout noise and keep the stable previous value.
+  // See: https://github.com/chaosblade-io/chaosblade/issues/1301
+  if (prev !== undefined && Math.abs(measured - prev) <= 1) {
+    return prev;
+  }
   return measured;
 }
 
@@ -238,6 +249,13 @@ export const MainContent: React.FC<Props> = ({ version, serverUrl }) => {
   const [chromeHeight, setChromeHeight] = useState<number>(
     CHROME_ROWS_RESERVE,
   );
+
+  // Hysteresis ref — tracks the last accepted chromeHeight synchronously
+  // so useLayoutEffect can pass it to acceptChromeMeasurement without
+  // adding chromeHeight to the deps array (which would cause an infinite
+  // effect loop). Updated synchronously before the async setState.
+  // See: https://github.com/chaosblade-io/chaosblade/issues/1301
+  const chromeHeightRef = useRef<number>(CHROME_ROWS_RESERVE);
 
   // Phase 3.2 — ref-transition version bump. React commits siblings
   // in JSX order; MainContent is mounted *before* Composer, so on
@@ -285,8 +303,11 @@ export const MainContent: React.FC<Props> = ({ version, serverUrl }) => {
     // (NaN propagates through ``< / >`` comparisons silently, which
     // would otherwise let a Yoga-glitched NaN reading land in state
     // and poison every downstream ``availableTerminalHeight`` math).
-    const accepted = acceptChromeMeasurement(measured, rows);
+    const accepted = acceptChromeMeasurement(measured, rows, chromeHeightRef.current);
     if (accepted === null) return;
+    // Sync the ref before async setState so the next useLayoutEffect
+    // invocation sees the latest accepted value for hysteresis.
+    chromeHeightRef.current = accepted;
     // Same-reference guard: setState with the same value would still
     // trigger a render; gate it explicitly so a no-op measure
     // doesn't churn the render loop.


### PR DESCRIPTION
## Summary

Fix screen jumping/flickering on Linux terminals during streaming caused by a ±1 oscillation feedback loop between `useLayoutEffect` and Ink's Yoga layout engine.

**Closes #1301**

## Root Cause

```
useLayoutEffect fires
  → measureElement() returns chrome height N
  → setChromeHeight(N) triggers re-render
  → Yoga re-layout shifts content by ±1 row (integer rounding / content reflow)
  → measureElement() returns N±1
  → setChromeHeight(N±1) triggers another re-render
  → ... infinite loop
```

macOS terminals (iTerm2, Terminal.app) support DEC Mode 2026 synchronized output, which atomically flushes multiple frames and masks the visual jump. Linux terminals (gnome-terminal, xterm, Konsole) lack this, so the oscillation is directly visible as screen flickering.

## Fix

Add a **±1 hysteresis band** to `acceptChromeMeasurement()`:

1. **`acceptChromeMeasurement`** gains an optional `prev` parameter. When the new measurement differs from `prev` by at most 1 row, it returns `prev` (treating the delta as Yoga rounding noise).

2. A **`chromeHeightRef`** (`useRef`) tracks the last accepted value synchronously, so `useLayoutEffect` can read it without adding `chromeHeight` to the deps array (which would cause an infinite effect loop).

3. **Test coverage**: 4 new test cases covering hysteresis suppression, real layout changes (>1 row), backward compatibility (no `prev`), and guard precedence.

## Changes

| File | Change | ~Lines |
|------|--------|--------|
| `tui/src/components/MainContent.tsx` | Add `prev?` param + hysteresis logic + `chromeHeightRef` + pass ref in effect | +23 |
| `tui/src/components/MainContent.test.ts` | New `describe("hysteresis")` block with 4 test cases | +38 |

## Backward Compatibility

- `prev` is optional — all existing call sites and tests work unchanged
- First render uses `CHROME_ROWS_RESERVE` as the initial ref value
- macOS behavior unchanged (only reduces wasted re-renders)

## Testing

```bash
cd blade-ai/tui && npm test -- --testPathPattern MainContent
```
