### PR TITLE
feat: integrate chaosblade-exec-python into CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ BLADE_EXEC_JVM_BRANCH=v1.8.0
 BLADE_EXEC_CPLUS_PROJECT=https://github.com/chaosblade-io/chaosblade-exec-cplus.git
 BLADE_EXEC_CPLUS_BRANCH=master
 
+# chaosblade-exec-python
+BLADE_EXEC_PYTHON_PROJECT=https://github.com/chaosblade-io/chaosblade-exec-python.git
+BLADE_EXEC_PYTHON_BRANCH=master
+
 # chaosblade-spec-go
 BLADE_SPEC_GO_PROJECT=https://github.com/chaosblade-io/chaosblade-spec-go.git
 BLADE_SPEC_GO_BRANCH=v1.8.0
@@ -419,6 +423,23 @@ endif
 	fi
 	@$(eval OUTPUT_DIR := $(call get_build_output_dir))
 	@cp -R $(BUILD_TARGET_CACHE)/chaosblade-exec-cplus/target/$(call get_platform_dir_name,$(GOOS),$(GOARCH))/* $(OUTPUT_DIR)/
+
+
+python-agent: ## Build python experimental scenarios.
+ifneq ($(BUILD_TARGET_CACHE)/chaosblade-exec-python, $(wildcard $(BUILD_TARGET_CACHE)/chaosblade-exec-python))
+	git clone -b $(BLADE_EXEC_PYTHON_BRANCH) $(BLADE_EXEC_PYTHON_PROJECT) $(BUILD_TARGET_CACHE)/chaosblade-exec-python
+else
+ifdef ALERTMSG
+	$(error $(ALERTMSG))
+endif
+	git -C $(BUILD_TARGET_CACHE)/chaosblade-exec-python pull origin $(BLADE_EXEC_PYTHON_BRANCH)
+endif
+	@echo "Building Python agent..."
+	@mkdir -p $(BUILD_TARGET_LIB)/python
+	@if [ -d "$(BUILD_TARGET_CACHE)/chaosblade-exec-python" ]; then \
+		cd $(BUILD_TARGET_CACHE)/chaosblade-exec-python && python setup.py bdist_wheel; \
+		cp $(BUILD_TARGET_CACHE)/chaosblade-exec-python/dist/*.whl $(BUILD_TARGET_LIB)/python/; \
+	fi
 
 
 cri: ## Build cri experimental scenarios.

--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,7 @@ endif
 endif
 	@echo "Building Python agent..."
 	@mkdir -p $(BUILD_TARGET_LIB)/python
+	@rm -rf $(BUILD_TARGET_LIB)/python/*
 	@if [ -d "$(BUILD_TARGET_CACHE)/chaosblade-exec-python" ]; then \
 		cd $(BUILD_TARGET_CACHE)/chaosblade-exec-python && \
 		python3 -m pip install --target $(BUILD_TARGET_LIB)/python . ; \

--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ endif
 	@mkdir -p $(BUILD_TARGET_LIB)/python
 	@if [ -d "$(BUILD_TARGET_CACHE)/chaosblade-exec-python" ]; then \
 		cd $(BUILD_TARGET_CACHE)/chaosblade-exec-python && \
-		pip install --target $(BUILD_TARGET_LIB)/python . ; \
+		python3 -m pip install --target $(BUILD_TARGET_LIB)/python . ; \
 	fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -437,8 +437,8 @@ endif
 	@echo "Building Python agent..."
 	@mkdir -p $(BUILD_TARGET_LIB)/python
 	@if [ -d "$(BUILD_TARGET_CACHE)/chaosblade-exec-python" ]; then \
-		cd $(BUILD_TARGET_CACHE)/chaosblade-exec-python && python setup.py bdist_wheel; \
-		cp $(BUILD_TARGET_CACHE)/chaosblade-exec-python/dist/*.whl $(BUILD_TARGET_LIB)/python/; \
+		cd $(BUILD_TARGET_CACHE)/chaosblade-exec-python && \
+		pip install --target $(BUILD_TARGET_LIB)/python . ; \
 	fi
 
 

--- a/build/spec/spec.go
+++ b/build/spec/spec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/chaosblade-io/chaosblade-spec-go/util"
 
 	"github.com/chaosblade-io/chaosblade/cli/cmd"
+	"github.com/chaosblade-io/chaosblade/exec/python"
 )
 
 var version = "1.7.4"
@@ -43,16 +44,18 @@ func main() {
 	k8sSpecFile := path.Join(filePath, fmt.Sprintf("chaosblade-k8s-spec-%s.yaml", version))
 	criSpecFile := path.Join(filePath, fmt.Sprintf("chaosblade-cri-spec-%s.yaml", version))
 	cplusSpecFile := path.Join(filePath, fmt.Sprintf("chaosblade-cplus-spec-%s.yaml", version))
+	pythonSpecFile := path.Join(filePath, fmt.Sprintf("chaosblade-python-spec-%s.yaml", version))
 	chaosSpecFile := path.Join(targetPath, "chaosblade.spec.yaml")
 
 	osModels := getOsModels(osSpecFile)
 	cloudModels := getCloudModels(cloudSpecFile)
 	jvmModels := getJvmModels(jvmSpecFile)
 	cplusModels := getCplusModels(cplusSpecFile)
+	pythonModels := getPythonModels(pythonSpecFile)
 	criModels := getCriModels(criSpecFile, jvmSpecFile)
 	k8sModels := getKubernetesModels(k8sSpecFile, jvmSpecFile)
 
-	models := mergeModels(osModels, cloudModels, jvmModels, cplusModels, criModels, k8sModels)
+	models := mergeModels(osModels, cloudModels, jvmModels, cplusModels, pythonModels, criModels, k8sModels)
 
 	file, err := os.OpenFile(chaosSpecFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o755)
 	if err != nil {
@@ -90,6 +93,14 @@ func getCplusModels(cplusSpecFile string) *spec.Models {
 	models, err := util.ParseSpecsToModel(cplusSpecFile, nil)
 	if err != nil {
 		log.Fatalf("parse cplus spec failed, %s", err)
+	}
+	return models
+}
+
+func getPythonModels(pythonSpecFile string) *spec.Models {
+	models, err := util.ParseSpecsToModel(pythonSpecFile, python.NewExecutor())
+	if err != nil {
+		log.Fatalf("parse python spec failed, %s", err)
 	}
 	return models
 }

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -32,6 +32,7 @@ func CmdInit() *baseCommand {
 	baseCmd.AddCommand(prepareCommand)
 	prepareCommand.AddCommand(&PrepareJvmCommand{})
 	prepareCommand.AddCommand(&PrepareCPlusCommand{})
+	prepareCommand.AddCommand(&PreparePythonCommand{})
 
 	// add revoke command
 	baseCmd.AddCommand(&RevokeCommand{})
@@ -54,6 +55,7 @@ func CmdInit() *baseCommand {
 	queryCommand.AddCommand(&QueryNetworkCommand{})
 	queryCommand.AddCommand(&QueryJvmCommand{})
 	queryCommand.AddCommand(&QueryK8sCommand{})
+	queryCommand.AddCommand(&QueryPythonCommand{})
 
 	// UPDATE 2023-12-30 Disable server command mode.
 

--- a/cli/cmd/exp.go
+++ b/cli/cmd/exp.go
@@ -39,6 +39,7 @@ import (
 	"github.com/chaosblade-io/chaosblade/exec/kubernetes"
 	"github.com/chaosblade-io/chaosblade/exec/middleware"
 	"github.com/chaosblade-io/chaosblade/exec/os"
+	"github.com/chaosblade-io/chaosblade/exec/python"
 	"github.com/chaosblade-io/chaosblade/version"
 )
 
@@ -127,6 +128,8 @@ func (ec *baseExpCommandService) registerSubCommands() {
 	ec.registerJvmExpCommands()
 	// register cplus
 	ec.registerCplusExpCommands()
+	// register python
+	ec.registerPythonExpCommands()
 	// register docker command
 	ec.registerDockerExpCommands()
 	// register cri command
@@ -213,6 +216,22 @@ func (ec *baseExpCommandService) registerCplusExpCommands() []*modelCommand {
 		cplusCommands = append(cplusCommands, command)
 	}
 	return cplusCommands
+}
+
+// registerPythonExpCommands
+func (ec *baseExpCommandService) registerPythonExpCommands() []*modelCommand {
+	file := path.Join(specutil.GetYamlHome(), fmt.Sprintf("chaosblade-python-spec-%s.yaml", version.Ver))
+	models, err := specutil.ParseSpecsToModel(file, python.NewExecutor())
+	if err != nil {
+		return nil
+	}
+	pythonCommands := make([]*modelCommand, 0)
+	for idx := range models.Models {
+		model := &models.Models[idx]
+		command := ec.registerExpCommand(model, "")
+		pythonCommands = append(pythonCommands, command)
+	}
+	return pythonCommands
 }
 
 // registerDockerExpCommands

--- a/cli/cmd/exp.go
+++ b/cli/cmd/exp.go
@@ -223,6 +223,7 @@ func (ec *baseExpCommandService) registerPythonExpCommands() []*modelCommand {
 	file := path.Join(specutil.GetYamlHome(), fmt.Sprintf("chaosblade-python-spec-%s.yaml", version.Ver))
 	models, err := specutil.ParseSpecsToModel(file, python.NewExecutor())
 	if err != nil {
+		log.Warnf(context.Background(), "failed to load python spec file %s: %v. Python commands will not be available.", file, err)
 		return nil
 	}
 	pythonCommands := make([]*modelCommand, 0)

--- a/cli/cmd/prepare.go
+++ b/cli/cmd/prepare.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	PrepareJvmType   = "jvm"
-	PrepareK8sType   = "k8s"
-	PrepareCPlusType = "cplus"
+	PrepareJvmType    = "jvm"
+	PrepareK8sType    = "k8s"
+	PrepareCPlusType  = "cplus"
+	PreparePythonType = "python"
 )
 
 // PrepareCommand defines attach command

--- a/cli/cmd/prepare.go
+++ b/cli/cmd/prepare.go
@@ -30,10 +30,9 @@ import (
 )
 
 const (
-	PrepareJvmType    = "jvm"
-	PrepareK8sType    = "k8s"
-	PrepareCPlusType  = "cplus"
-	PreparePythonType = "python"
+	PrepareJvmType   = "jvm"
+	PrepareK8sType   = "k8s"
+	PrepareCPlusType = "cplus"
 )
 
 // PrepareCommand defines attach command

--- a/cli/cmd/prepare_python.go
+++ b/cli/cmd/prepare_python.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+
+	"github.com/chaosblade-io/chaosblade/exec/python"
+)
+
+type PreparePythonCommand struct {
+	baseCommand
+	port         int
+	pythonPath   string
+	targetScript string
+}
+
+func (pc *PreparePythonCommand) Init() {
+	pc.command = &cobra.Command{
+		Use:   "python",
+		Short: "Active python agent.",
+		Long:  "Active python agent.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pc.preparePython()
+		},
+		Example: pc.prepareExample(),
+	}
+	pc.command.Flags().IntVarP(&pc.port, "port", "p", 9526, "the server port of python agent")
+	pc.command.Flags().StringVar(&pc.pythonPath, "python-path", "", "the path of python interpreter")
+	pc.command.Flags().StringVar(&pc.targetScript, "target-script", "", "the path of target python script")
+	pc.command.MarkFlagRequired("python-path")
+	pc.command.MarkFlagRequired("target-script")
+}
+
+func (pc *PreparePythonCommand) prepareExample() string {
+	return `prepare python --port 9526 --python-path /path/to/python --target-script /path/to/script.py`
+}
+
+func (pc *PreparePythonCommand) preparePython() error {
+	ctx := context.Background()
+	portStr := strconv.Itoa(pc.port)
+	record, err := GetDS().QueryRunningPreByTypeAndProcess(python.PreparePythonType, portStr, "")
+	if err != nil {
+		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
+		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
+	}
+	if record == nil || record.Status != Running {
+		record, err = insertPrepareRecord(python.PreparePythonType, portStr, portStr, pc.targetScript)
+		if err != nil {
+			log.Errorf(ctx, util.GetRunFuncName(), spec.DatabaseError.Sprintf("insert", err))
+			return spec.ResponseFailWithFlags(spec.DatabaseError, "insert", err)
+		}
+	}
+	ctx = context.WithValue(ctx, spec.Uid, record.Uid)
+	response := python.Prepare(ctx, portStr, pc.pythonPath, pc.targetScript)
+	return handlePrepareResponse(ctx, pc.command, response)
+}

--- a/cli/cmd/prepare_python.go
+++ b/cli/cmd/prepare_python.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -39,8 +40,8 @@ type PreparePythonCommand struct {
 func (pc *PreparePythonCommand) Init() {
 	pc.command = &cobra.Command{
 		Use:   "python",
-		Short: "Active python agent.",
-		Long:  "Active python agent.",
+		Short: "Activate python agent.",
+		Long:  "Activate python agent.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pc.preparePython()
 		},
@@ -60,19 +61,28 @@ func (pc *PreparePythonCommand) prepareExample() string {
 func (pc *PreparePythonCommand) preparePython() error {
 	ctx := context.Background()
 	portStr := strconv.Itoa(pc.port)
+
+	// Convert target-script to absolute path to ensure revoke works correctly
+	// regardless of the current working directory
+	absTargetScript, err := filepath.Abs(pc.targetScript)
+	if err != nil {
+		log.Errorf(ctx, "failed to resolve absolute path for %s: %v", pc.targetScript, err)
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "target-script", pc.targetScript, "cannot resolve absolute path")
+	}
+
 	record, err := GetDS().QueryRunningPreByTypeAndProcess(python.PreparePythonType, portStr, "")
 	if err != nil {
 		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
 	if record == nil || record.Status != Running {
-		record, err = insertPrepareRecord(python.PreparePythonType, portStr, portStr, pc.targetScript)
+		record, err = insertPrepareRecord(python.PreparePythonType, portStr, portStr, absTargetScript)
 		if err != nil {
 			log.Errorf(ctx, util.GetRunFuncName(), spec.DatabaseError.Sprintf("insert", err))
 			return spec.ResponseFailWithFlags(spec.DatabaseError, "insert", err)
 		}
 	}
 	ctx = context.WithValue(ctx, spec.Uid, record.Uid)
-	response := python.Prepare(ctx, portStr, pc.pythonPath, pc.targetScript)
+	response := python.Prepare(ctx, portStr, pc.pythonPath, absTargetScript)
 	return handlePrepareResponse(ctx, pc.command, response)
 }

--- a/cli/cmd/query_python.go
+++ b/cli/cmd/query_python.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+
+	"github.com/chaosblade-io/chaosblade/exec/python"
+)
+
+type QueryPythonCommand struct {
+	baseCommand
+}
+
+func (qpc *QueryPythonCommand) Init() {
+	qpc.command = &cobra.Command{
+		Use:   "python <UID>",
+		Short: "Query status of the specify python preparation",
+		Long:  "Query status of the specify python preparation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.WithValue(context.Background(), spec.Uid, args[0])
+			return qpc.queryPythonExpStatus(ctx, cmd)
+		},
+		Example: qpc.queryPythonExample(),
+	}
+}
+
+func (qpc *QueryPythonCommand) queryPythonExample() string {
+	return `blade query python 29c3f9dab4abbc79`
+}
+
+// queryPythonExpStatus by uid
+func (qpc *QueryPythonCommand) queryPythonExpStatus(ctx context.Context, command *cobra.Command) error {
+	uid := ctx.Value(spec.Uid).(string)
+	record, err := GetDS().QueryPreparationByUid(uid)
+	if err != nil {
+		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
+	}
+	if record == nil {
+		return spec.ResponseFailWithFlags(spec.DataNotFound, uid)
+	}
+	response := python.Status(ctx, record.Port)
+	if response.Success {
+		command.Println(response.Print())
+	} else {
+		return errors.New(response.Error())
+	}
+	return nil
+}

--- a/cli/cmd/query_python.go
+++ b/cli/cmd/query_python.go
@@ -34,8 +34,8 @@ type QueryPythonCommand struct {
 func (qpc *QueryPythonCommand) Init() {
 	qpc.command = &cobra.Command{
 		Use:   "python <UID>",
-		Short: "Query status of the specify python preparation",
-		Long:  "Query status of the specify python preparation",
+		Short: "Query status of the specified python preparation",
+		Long:  "Query status of the specified python preparation",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.WithValue(context.Background(), spec.Uid, args[0])

--- a/cli/cmd/revoke.go
+++ b/cli/cmd/revoke.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/chaosblade-io/chaosblade/exec/cplus"
 	"github.com/chaosblade-io/chaosblade/exec/jvm"
+	"github.com/chaosblade-io/chaosblade/exec/python"
 )
 
 type RevokeCommand struct {
@@ -69,6 +70,8 @@ func (rc *RevokeCommand) runRevoke(args []string) error {
 		response = jvm.Detach(ctx, record.Port)
 	case PrepareCPlusType:
 		response = cplus.Revoke(ctx, record.Port)
+	case PreparePythonType:
+		response = python.Revoke(ctx, record.Port)
 	case PrepareK8sType:
 		args := fmt.Sprintf("delete ns chaosblade")
 		response = channel.Run(ctx, "kubectl", args)

--- a/cli/cmd/revoke.go
+++ b/cli/cmd/revoke.go
@@ -71,7 +71,7 @@ func (rc *RevokeCommand) runRevoke(args []string) error {
 	case PrepareCPlusType:
 		response = cplus.Revoke(ctx, record.Port)
 	case python.PreparePythonType:
-		response = python.Revoke(ctx, record.Port)
+		response = python.Revoke(ctx, record.Pid)
 	case PrepareK8sType:
 		args := fmt.Sprintf("delete ns chaosblade")
 		response = channel.Run(ctx, "kubectl", args)

--- a/cli/cmd/revoke.go
+++ b/cli/cmd/revoke.go
@@ -70,7 +70,7 @@ func (rc *RevokeCommand) runRevoke(args []string) error {
 		response = jvm.Detach(ctx, record.Port)
 	case PrepareCPlusType:
 		response = cplus.Revoke(ctx, record.Port)
-	case PreparePythonType:
+	case python.PreparePythonType:
 		response = python.Revoke(ctx, record.Port)
 	case PrepareK8sType:
 		args := fmt.Sprintf("delete ns chaosblade")

--- a/exec/python/executor.go
+++ b/exec/python/executor.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package python
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	neturl "net/url"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+
+	"github.com/chaosblade-io/chaosblade/data"
+)
+
+// Executor for python experiment
+type Executor struct {
+	channel spec.Channel
+}
+
+func NewExecutor() *Executor {
+	return &Executor{
+		channel: channel.NewLocalChannel(),
+	}
+}
+
+func (e *Executor) Name() string {
+	return "python"
+}
+
+func (e *Executor) SetChannel(channel spec.Channel) {
+	e.channel = channel
+}
+
+func (e *Executor) Exec(uid string, ctx context.Context, model *spec.ExpModel) *spec.Response {
+	port, resp := e.getPortFromDB(ctx, uid, model)
+	if resp != nil {
+		return resp
+	}
+
+	var url string
+	if _, ok := spec.IsDestroy(ctx); ok {
+		url = e.destroyUrl(port, uid)
+	} else {
+		url = e.createUrl(port, uid, model)
+	}
+	result, err, code := util.Curl(ctx, url)
+	if err != nil {
+		log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, err))
+		return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, err)
+	}
+	if code == 200 {
+		var resp spec.Response
+		err := json.Unmarshal([]byte(result), &resp)
+		if err != nil {
+			log.Errorf(ctx, "%s", spec.ResultUnmarshalFailed.Sprintf(result, err))
+			return spec.ResponseFailWithFlags(spec.ResultUnmarshalFailed, result, err)
+		}
+		return &resp
+	}
+	log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, result))
+	return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, result)
+}
+
+func (e *Executor) createUrl(port, suid string, model *spec.ExpModel) string {
+	url := fmt.Sprintf("http://%s:%s/create?target=%s&suid=%s&action=%s",
+		"127.0.0.1", port, model.Target, suid, model.ActionName)
+	for k, v := range model.ActionFlags {
+		if v == "" || v == "false" {
+			continue
+		}
+		if k == "timeout" {
+			continue
+		}
+		url = fmt.Sprintf("%s&%s=%s", url, k, neturl.QueryEscape(v))
+	}
+	return url
+}
+
+func (e *Executor) destroyUrl(port, uid string) string {
+	return fmt.Sprintf("http://%s:%s/destroy?suid=%s",
+		"127.0.0.1", port, uid)
+}
+
+var db = data.GetSource()
+
+func (e *Executor) getPortFromDB(ctx context.Context, uid string, model *spec.ExpModel) (string, *spec.Response) {
+	port := model.ActionFlags["port"]
+	record, err := db.QueryRunningPreByTypeAndProcess(PreparePythonType, port, "")
+	if err != nil {
+		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
+		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
+	}
+	if record == nil {
+		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "no running python preparation record found"))
+		return "", spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "no running python preparation record found")
+	}
+	return record.Port, nil
+}

--- a/exec/python/executor.go
+++ b/exec/python/executor.go
@@ -103,6 +103,9 @@ var db = data.GetSource()
 
 func (e *Executor) getPortFromDB(ctx context.Context, uid string, model *spec.ExpModel) (string, *spec.Response) {
 	port := model.ActionFlags["port"]
+	if port == "" {
+		port = "9526" // default port, matching prepare command default
+	}
 	record, err := db.QueryRunningPreByTypeAndProcess(PreparePythonType, port, "")
 	if err != nil {
 		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))

--- a/exec/python/executor.go
+++ b/exec/python/executor.go
@@ -102,18 +102,18 @@ func (e *Executor) destroyUrl(port, uid string) string {
 var db = data.GetSource()
 
 func (e *Executor) getPortFromDB(ctx context.Context, uid string, model *spec.ExpModel) (string, *spec.Response) {
-	port := model.ActionFlags["port"]
-	if port == "" {
-		port = "9526" // default port, matching prepare command default
-	}
-	record, err := db.QueryRunningPreByTypeAndProcess(PreparePythonType, port, "")
+	// Query all running Python preparations
+	// Since there's typically only one Python agent per instance, use the first running record
+	records, err := db.QueryPreparationRecords(PreparePythonType, "Running", "", "", "1", true)
 	if err != nil {
 		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
 		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
-	if record == nil {
-		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "no running python preparation record found"))
-		return "", spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "no running python preparation record found")
+	
+	if len(records) == 0 {
+		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", "", "no running python preparation record found"))
+		return "", spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", "", "no running python preparation record found")
 	}
-	return record.Port, nil
+	
+	return records[0].Port, nil
 }

--- a/exec/python/executor.go
+++ b/exec/python/executor.go
@@ -109,11 +109,11 @@ func (e *Executor) getPortFromDB(ctx context.Context, uid string, model *spec.Ex
 		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
 		return "", spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
-	
+
 	if len(records) == 0 {
 		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", "", "no running python preparation record found"))
 		return "", spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", "", "no running python preparation record found")
 	}
-	
+
 	return records[0].Port, nil
 }

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -33,7 +33,7 @@ import (
 const (
 	PreparePythonType = "python"
 	ApplicationName   = "chaosblade-exec-python"
-	
+
 	// Response messages
 	MsgAgentAlreadyStarted = "python agent has been started"
 	MsgHookInstalled       = "python agent hook installed, restart target app to activate"

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -84,18 +84,17 @@ func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.
 	}
 	// Check if Python agent is already running (idempotent behavior like CPlus)
 	statusResponse := Status(ctx, port)
-	if statusResponse.Success && statusResponse.Result != nil {
-		if result, ok := statusResponse.Result.(string); ok && !strings.Contains(result, "not started") {
-			return spec.ReturnSuccess("python agent has been started")
-		}
+	if statusResponse.Success {
+		// Agent is reachable and responding — already prepared
+		return spec.ReturnSuccess("python agent has been started")
 	}
-	// Check if port is used by other program
-	portInUse := util.CheckPortInUse(port)
-	if portInUse {
-		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "the port has been used by other program"))
-		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used by other program")
+	// If connection refused, agent is not running — safe to proceed
+	if statusResponse.Err != nil && strings.Contains(statusResponse.Err.Error(), "connection refused") {
+		return spec.ReturnSuccess("success")
 	}
-	return spec.ReturnSuccess("success")
+	// Other error (e.g. port used by non-agent process)
+	log.Errorf(ctx, "port %s check failed: %v", port, statusResponse.Err)
+	return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used by other program")
 }
 
 func generateSiteCustomize(ctx context.Context, port, pythonPath, targetDir string) *spec.Response {
@@ -163,12 +162,13 @@ func Revoke(ctx context.Context, port string) *spec.Response {
 }
 
 // Status checks whether the python agent HTTP endpoint is reachable.
+// Returns success only when the agent is actually running and responding.
 func Status(ctx context.Context, port string) *spec.Response {
 	url := getServiceUrl(port, "status")
 	result, err, code := util.Curl(ctx, url)
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			return spec.ReturnSuccess("python agent is not started, hook installed")
+			return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, "python agent is not running")
 		}
 		log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, err))
 		return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, err)

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -39,9 +39,7 @@ const (
 	MsgHookInstalled       = "python agent hook installed, restart target app to activate"
 )
 
-var (
-	pythonLibPath = path.Join(util.GetLibHome(), "python")
-)
+var pythonLibPath = path.Join(util.GetLibHome(), "python")
 
 // Prepare installs the python agent hook into the target script directory.
 // The python agent runs in-process, so this only generates sitecustomize.py

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -82,10 +82,18 @@ func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.
 		log.Errorf(ctx, "python agent library not found: %s. Please run 'make python-agent' first", pythonLibPath)
 		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, pythonLibPath)
 	}
+	// Check if Python agent is already running (idempotent behavior like CPlus)
+	statusResponse := Status(ctx, port)
+	if statusResponse.Success && statusResponse.Result != nil {
+		if result, ok := statusResponse.Result.(string); ok && !strings.Contains(result, "not started") {
+			return spec.ReturnSuccess("python agent has been started")
+		}
+	}
+	// Check if port is used by other program
 	portInUse := util.CheckPortInUse(port)
 	if portInUse {
-		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "the port has been used"))
-		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used")
+		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "the port has been used by other program"))
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used by other program")
 	}
 	return spec.ReturnSuccess("success")
 }

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -33,6 +33,10 @@ import (
 const (
 	PreparePythonType = "python"
 	ApplicationName   = "chaosblade-exec-python"
+	
+	// Response messages
+	MsgAgentAlreadyStarted = "python agent has been started"
+	MsgHookInstalled       = "python agent hook installed, restart target app to activate"
 )
 
 var (
@@ -50,7 +54,7 @@ func Prepare(ctx context.Context, port, pythonPath, targetScript string) *spec.R
 
 	// If agent is already running, return success (idempotent)
 	if response.Result != nil {
-		if result, ok := response.Result.(string); ok && result == "python agent has been started" {
+		if result, ok := response.Result.(string); ok && result == MsgAgentAlreadyStarted {
 			return response
 		}
 	}
@@ -71,7 +75,7 @@ func Prepare(ctx context.Context, port, pythonPath, targetScript string) *spec.R
 		return response
 	}
 
-	return spec.ReturnSuccess("python agent hook installed, restart target app to activate")
+	return spec.ReturnSuccess(MsgHookInstalled)
 }
 
 func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.Response {
@@ -93,7 +97,7 @@ func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.
 	statusResponse := Status(ctx, port)
 	if statusResponse.Success {
 		// Agent is reachable and responding — already prepared
-		return spec.ReturnSuccess("python agent has been started")
+		return spec.ReturnSuccess(MsgAgentAlreadyStarted)
 	}
 	// Check if port is used by another process
 	portInUse := util.CheckPortInUse(port)
@@ -141,17 +145,12 @@ func generatePythonPathEnv(targetDir string) *spec.Response {
 
 // Revoke removes the python agent hook. The agent itself lives in the target
 // python process and will be removed on the next process restart.
-func Revoke(ctx context.Context, port string) *spec.Response {
-	record, err := db.QueryRunningPreByTypeAndProcess(PreparePythonType, port, "")
-	if err != nil {
-		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
-		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
-	}
-	if record == nil || record.Pid == "" {
+func Revoke(ctx context.Context, targetScript string) *spec.Response {
+	if targetScript == "" {
 		return spec.ReturnSuccess("no hook installed")
 	}
 
-	targetDir := path.Dir(record.Pid)
+	targetDir := path.Dir(targetScript)
 	siteCustomizePath := path.Join(targetDir, "sitecustomize.py")
 	envFile := path.Join(targetDir, "chaosblade_python_env.sh")
 

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 The ChaosBlade Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package python
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/chaosblade-io/chaosblade-spec-go/channel"
+	"github.com/chaosblade-io/chaosblade-spec-go/log"
+	"github.com/chaosblade-io/chaosblade-spec-go/spec"
+	"github.com/chaosblade-io/chaosblade-spec-go/util"
+)
+
+const (
+	PreparePythonType = "python"
+	ApplicationName   = "chaosblade-exec-python"
+)
+
+var (
+	pythonLibPath = path.Join(util.GetLibHome(), "python")
+)
+
+// Prepare installs the python agent hook into the target script directory.
+// The python agent runs in-process, so this only generates sitecustomize.py
+// and records the preparation; no separate process is started.
+func Prepare(ctx context.Context, port, pythonPath, targetScript string) *spec.Response {
+	response := preCheck(ctx, port, pythonPath, targetScript)
+	if !response.Success {
+		return response
+	}
+
+	targetDir := path.Dir(targetScript)
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		log.Errorf(ctx, "create target script directory %s failed, %v", targetDir, err)
+		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, targetDir)
+	}
+
+	response = generateSiteCustomize(ctx, port, pythonPath, targetDir)
+	if !response.Success {
+		return response
+	}
+
+	response = generatePythonPathEnv(targetDir)
+	if !response.Success {
+		return response
+	}
+
+	return Status(ctx, port)
+}
+
+func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.Response {
+	if pythonPath == "" {
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "python-path")
+	}
+	if targetScript == "" {
+		return spec.ResponseFailWithFlags(spec.ParameterLess, "target-script")
+	}
+	if !util.IsExist(pythonPath) {
+		log.Errorf(ctx, "%s", spec.ChaosbladeFileNotFound.Sprintf(pythonPath))
+		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, pythonPath)
+	}
+	portInUse := util.CheckPortInUse(port)
+	if portInUse {
+		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "the port has been used"))
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used")
+	}
+	return spec.ReturnSuccess("success")
+}
+
+func generateSiteCustomize(ctx context.Context, port, pythonPath, targetDir string) *spec.Response {
+	siteCustomizePath := path.Join(targetDir, "sitecustomize.py")
+	content := fmt.Sprintf(`import sys
+import os
+
+# Add chaosblade python agent library path
+agent_path = "%s"
+if agent_path not in sys.path:
+    sys.path.insert(0, agent_path)
+
+# Configure agent port
+os.environ["CHAOSBLADE_PYTHON_AGENT_PORT"] = "%s"
+
+try:
+    import chaosblade
+    chaosblade.start()
+except Exception as e:
+    print("[chaosblade] failed to start python agent: {}".format(e), file=sys.stderr)
+`, pythonLibPath, port)
+
+	if err := os.WriteFile(siteCustomizePath, []byte(content), 0o644); err != nil {
+		log.Errorf(ctx, "write sitecustomize.py failed, %v", err)
+		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, siteCustomizePath)
+	}
+
+	return channel.NewLocalChannel().Run(ctx, pythonPath, fmt.Sprintf("-m py_compile %s", siteCustomizePath))
+}
+
+func generatePythonPathEnv(targetDir string) *spec.Response {
+	envFile := path.Join(targetDir, "chaosblade_python_env.sh")
+	value := fmt.Sprintf("export PYTHONPATH=\"%s:%s:$PYTHONPATH\"\n", targetDir, pythonLibPath)
+	if err := os.WriteFile(envFile, []byte(value), 0o644); err != nil {
+		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, envFile)
+	}
+	return spec.ReturnSuccess("success")
+}
+
+// Revoke removes the python agent hook. The agent itself lives in the target
+// python process and will be removed on the next process restart.
+func Revoke(ctx context.Context, port string) *spec.Response {
+	record, err := db.QueryRunningPreByTypeAndProcess(PreparePythonType, port, "")
+	if err != nil {
+		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
+		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
+	}
+	if record == nil || record.Process == "" {
+		return spec.ReturnSuccess("no hook installed")
+	}
+
+	targetDir := path.Dir(record.Process)
+	siteCustomizePath := path.Join(targetDir, "sitecustomize.py")
+	envFile := path.Join(targetDir, "chaosblade_python_env.sh")
+
+	if util.IsExist(siteCustomizePath) {
+		if err := os.Remove(siteCustomizePath); err != nil {
+			log.Errorf(ctx, "remove sitecustomize.py failed, %v", err)
+			return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, siteCustomizePath)
+		}
+	}
+	if util.IsExist(envFile) {
+		_ = os.Remove(envFile)
+	}
+
+	return spec.ReturnSuccess("success")
+}
+
+// Status checks whether the python agent HTTP endpoint is reachable.
+func Status(ctx context.Context, port string) *spec.Response {
+	url := getServiceUrl(port, "status")
+	result, err, code := util.Curl(ctx, url)
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			return spec.ReturnSuccess("python agent is not started, hook installed")
+		}
+		log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, err))
+		return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, err)
+	}
+	if code != 200 {
+		log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, result))
+		return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, result)
+	}
+	return spec.ReturnSuccess(result)
+}
+
+func getServiceUrl(port, action string) string {
+	return fmt.Sprintf("http://127.0.0.1:%s/%s", port, action)
+}

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -95,12 +95,10 @@ agent_path = "%s"
 if agent_path not in sys.path:
     sys.path.insert(0, agent_path)
 
-# Configure agent port
-os.environ["CHAOSBLADE_PYTHON_AGENT_PORT"] = "%s"
-
 try:
-    import chaosblade
-    chaosblade.start()
+    from chaosblade import ChaosBladeAgent
+    _port = int(os.environ.get("CHAOSBLADE_PYTHON_AGENT_PORT", "%s"))
+    ChaosBladeAgent(port=_port).start()
 except Exception as e:
     print("[chaosblade] failed to start python agent: {}".format(e), file=sys.stderr)
 `, pythonLibPath, port)
@@ -130,11 +128,11 @@ func Revoke(ctx context.Context, port string) *spec.Response {
 		log.Errorf(ctx, "%s", spec.DatabaseError.Sprintf("query", err))
 		return spec.ResponseFailWithFlags(spec.DatabaseError, "query", err)
 	}
-	if record == nil || record.Process == "" {
+	if record == nil || record.Pid == "" {
 		return spec.ReturnSuccess("no hook installed")
 	}
 
-	targetDir := path.Dir(record.Process)
+	targetDir := path.Dir(record.Pid)
 	siteCustomizePath := path.Join(targetDir, "sitecustomize.py")
 	envFile := path.Join(targetDir, "chaosblade_python_env.sh")
 

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -48,6 +48,13 @@ func Prepare(ctx context.Context, port, pythonPath, targetScript string) *spec.R
 		return response
 	}
 
+	// If agent is already running, return success (idempotent)
+	if response.Result != nil {
+		if result, ok := response.Result.(string); ok && result == "python agent has been started" {
+			return response
+		}
+	}
+
 	targetDir := path.Dir(targetScript)
 	if err := os.MkdirAll(targetDir, 0o755); err != nil {
 		log.Errorf(ctx, "create target script directory %s failed, %v", targetDir, err)
@@ -64,7 +71,7 @@ func Prepare(ctx context.Context, port, pythonPath, targetScript string) *spec.R
 		return response
 	}
 
-	return Status(ctx, port)
+	return spec.ReturnSuccess("python agent hook installed, restart target app to activate")
 }
 
 func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.Response {
@@ -88,13 +95,13 @@ func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.
 		// Agent is reachable and responding — already prepared
 		return spec.ReturnSuccess("python agent has been started")
 	}
-	// If connection refused, agent is not running — safe to proceed
-	if statusResponse.Err != nil && strings.Contains(statusResponse.Err.Error(), "connection refused") {
-		return spec.ReturnSuccess("success")
+	// Check if port is used by another process
+	portInUse := util.CheckPortInUse(port)
+	if portInUse {
+		log.Errorf(ctx, "%s", spec.ParameterInvalid.Sprintf("port", port, "the port has been used by other program"))
+		return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used by other program")
 	}
-	// Other error (e.g. port used by non-agent process)
-	log.Errorf(ctx, "port %s check failed: %v", port, statusResponse.Err)
-	return spec.ResponseFailWithFlags(spec.ParameterInvalid, "port", port, "the port has been used by other program")
+	return spec.ReturnSuccess("success")
 }
 
 func generateSiteCustomize(ctx context.Context, port, pythonPath, targetDir string) *spec.Response {

--- a/exec/python/python.go
+++ b/exec/python/python.go
@@ -18,6 +18,7 @@ package python
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -76,6 +77,10 @@ func preCheck(ctx context.Context, port, pythonPath, targetScript string) *spec.
 	if !util.IsExist(pythonPath) {
 		log.Errorf(ctx, "%s", spec.ChaosbladeFileNotFound.Sprintf(pythonPath))
 		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, pythonPath)
+	}
+	if !util.IsExist(pythonLibPath) {
+		log.Errorf(ctx, "python agent library not found: %s. Please run 'make python-agent' first", pythonLibPath)
+		return spec.ResponseFailWithFlags(spec.ChaosbladeFileNotFound, pythonLibPath)
 	}
 	portInUse := util.CheckPortInUse(port)
 	if portInUse {
@@ -164,7 +169,12 @@ func Status(ctx context.Context, port string) *spec.Response {
 		log.Errorf(ctx, "%s", spec.HttpExecFailed.Sprintf(url, result))
 		return spec.ResponseFailWithFlags(spec.HttpExecFailed, url, result)
 	}
-	return spec.ReturnSuccess(result)
+	var resp spec.Response
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		log.Errorf(ctx, "%s", spec.ResultUnmarshalFailed.Sprintf(result, err))
+		return spec.ResponseFailWithFlags(spec.ResultUnmarshalFailed, result, err)
+	}
+	return &resp
 }
 
 func getServiceUrl(port, action string) string {


### PR DESCRIPTION
## Summary

Integrate chaosblade-exec-python into the main chaosblade CLI, enabling Python application fault injection through `blade create python ...` commands.

Fixes #1319

## Changes

### New Files

1. **exec/python/executor.go** - HTTP executor for Python experiments
   - Implements `spec.Executor` interface
   - Uses flat-path URLs: `http://127.0.0.1:port/create`, `http://127.0.0.1:port/destroy`
   - Queries port from database using `PreparePythonType`

2. **exec/python/python.go** - Agent lifecycle management
   - `Prepare()`: Installs hook (generates sitecustomize.py, sets PYTHONPATH)
   - `Revoke()`: Removes hook (agent removed on next process restart)
   - `Status()`: Checks agent status via HTTP
   - **Key difference from CPlus**: No separate process spawned; agent runs in-process

3. **cli/cmd/prepare_python.go** - Prepare command
   - Usage: `blade prepare python --port 9526 --python-path /path/to/python --target-script /path/to/script.py`
   - Flags: `--port` (default 9526), `--python-path` (required), `--target-script` (required)

4. **cli/cmd/query_python.go** - Query command
   - Usage: `blade query python <UID>`
   - Queries preparation record and shows agent status

### Modified Files

1. **cli/cmd/cmd.go** - Register `PreparePythonCommand` and `QueryPythonCommand`
2. **cli/cmd/revoke.go** - Add Python case in revoke switch
3. **cli/cmd/exp.go** - Add `registerPythonExpCommands()` to load Python spec YAML
4. **cli/cmd/prepare.go** - Add `PreparePythonType = "python"` constant
5. **build/spec/spec.go** - Add `getPythonModels()` to parse Python spec
6. **Makefile** - Add `python-agent` build target

## Architecture Design

### HTTP Executor Layer
References **CPlus's simpler pattern**:
- Flat-path URL: `http://127.0.0.1:port/create` (not JVM's sandbox prefix)
- Simple request/response handling
- Compatible with Python agent's HTTP API

### Agent Lifecycle
Closer to **JVM** (in-process injection):
- Python agent runs **inside the target process** (loaded via `sitecustomize.py`)
- HTTP server runs as daemon thread within target process
- `prepare` = install hook into target's startup configuration
- `revoke` = remove hook (agent removed on next process restart)
- Unlike CPlus: No standalone proxy process spawned
- Unlike JVM: Cannot dynamically attach (requires startup loading)

### Response Format
Compatible with Go's `spec.Response`:
```json
{"code": 200, "success": true, "error": "", "result": {...}}
```

## Testing

- [ ] Compile successfully with `make build`
- [ ] `blade prepare python --help` shows correct usage
- [ ] `blade create python ...` commands are registered from spec YAML
- [ ] Integration test with actual Python application

## Dependencies

This PR requires:
1. **chaosblade-exec-python** repository with spec exporter (PR #3 in chaosblade-exec-python)
2. Python spec YAML file: `chaosblade-python-spec-<version>.yaml`

## Notes

- Follows established patterns from JVM and CPlus integrations
- Maintains backward compatibility (no breaking changes)
- Zero runtime dependencies for core package
- DCO signed-off

---
*Automated by github-manager-bot*