### PR TITLE
fix(blade-ai): cap file-read tool output to prevent context overflow

### DIFF
--- a/blade-ai/src/chaos_agent/tools/file_reader.py
+++ b/blade-ai/src/chaos_agent/tools/file_reader.py
@@ -26,6 +26,11 @@ _DENIED_SUFFIXES = (
     ".pem", ".key", ".p12", ".pfx", ".jks",
 )
 
+# Maximum number of bytes to read from a single file.  Larger files are
+# truncated to avoid overwhelming the LLM context / inflating token cost,
+# mirroring the MAX_RESULTS cap in file_search.py.
+MAX_FILE_BYTES = 256 * 1024  # 256 KB
+
 
 def _is_denylisted(path: Path) -> tuple[bool, str]:
     """Check if a path is in the deny-list of sensitive locations."""
@@ -86,5 +91,15 @@ def safe_read_file(file_path: str) -> str:
             return header + "\n" + "\n".join(f"  - {i}" for i in items)
         return f"{header} (empty)"
 
-    # File: read content
+    # File: read content, capped to avoid overwhelming the LLM context
+    size = p.stat().st_size
+    if size > MAX_FILE_BYTES:
+        # Read only the byte prefix from disk; errors="ignore" drops a
+        # trailing multibyte char that may be split at the cut point.
+        with p.open("rb") as f:
+            head = f.read(MAX_FILE_BYTES).decode("utf-8", errors="ignore")
+        return (
+            head
+            + f"\n\n[truncated: showing first {MAX_FILE_BYTES} of {size} bytes]"
+        )
     return p.read_text(encoding="utf-8")

--- a/blade-ai/tests/test_tools/test_file_reader.py
+++ b/blade-ai/tests/test_tools/test_file_reader.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from chaos_agent.tools.file_reader import safe_read_file, _is_denylisted
+from chaos_agent.tools.file_reader import (
+    MAX_FILE_BYTES,
+    safe_read_file,
+    _is_denylisted,
+)
 
 
 class TestSafeReadFile:
@@ -82,6 +86,30 @@ class TestSafeReadFile:
 
         result = safe_read_file("~/test.txt")
         assert result == "home content"
+
+    def test_file_at_cap_not_truncated(self, tmp_path):
+        """A file exactly at the cap is returned in full, no notice."""
+        f = tmp_path / "exact.txt"
+        f.write_bytes(b"A" * MAX_FILE_BYTES)
+        result = safe_read_file(str(f))
+        assert result == "A" * MAX_FILE_BYTES
+        assert "truncated" not in result
+
+    def test_large_file_truncated(self, tmp_path):
+        """A file over the cap is truncated to the cap plus a notice."""
+        f = tmp_path / "big.txt"
+        f.write_bytes(b"A" * (MAX_FILE_BYTES + 5000))
+        result = safe_read_file(str(f))
+        assert result.count("A") == MAX_FILE_BYTES
+        assert f"[truncated: showing first {MAX_FILE_BYTES} of {MAX_FILE_BYTES + 5000} bytes]" in result
+
+    def test_truncation_multibyte_boundary(self, tmp_path):
+        """A multibyte char split at the cut point does not crash."""
+        f = tmp_path / "mb.txt"
+        # Emoji is 4 bytes; fill past the cap so the cut lands mid-char.
+        f.write_bytes("😀".encode("utf-8") * (MAX_FILE_BYTES // 4 + 100))
+        result = safe_read_file(str(f))
+        assert "[truncated" in result
 
 
 class TestIsDenylisted:


### PR DESCRIPTION
## Summary

`safe_read_file()` in `blade-ai/src/chaos_agent/tools/file_reader.py` read entire files with no size limit, so a large file dumped its full contents into the LLM context and inflated token cost.

This caps reads at `MAX_FILE_BYTES` (256 KB): files over the cap return a byte-exact prefix plus a `[truncated: showing first N of M bytes]` notice, mirroring the `MAX_RESULTS` cap already used in `file_search.py` ("to avoid overwhelming the LLM context").

Fixes #1325

## Design choices

- **Cap = 256 KB**, truncate-not-reject (agent still gets partial content).
- **Head-only** truncation, matching `file_search.py`'s "showing first X of Y" style.
- **Byte-exact prefix** read straight from disk (`open("rb").read(N)`), so a huge file is never fully loaded into memory; `errors="ignore"` drops a trailing multibyte char split at the cut point.
- No signature change, no new imports (stdlib only), no refactor of surrounding code.

## Out of scope

`read_text(encoding="utf-8")` still raises on non-UTF-8 / binary files below the cap — noted in #1325, left for a separate PR.

## Testing

Verified locally: small file returned unchanged; oversized file bounded to the cap with the notice; multibyte file at the boundary doesn't crash; directory listing and deny-list behavior unchanged.
