### PR TITLE
fix(blade-ai): validate CLI --output format and reject unknown values

### DIFF
--- a/blade-ai/src/chaos_agent/cli/commands/capabilities_cmd.py
+++ b/blade-ai/src/chaos_agent/cli/commands/capabilities_cmd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import typer
 
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 from chaos_agent.config.settings import settings
 from chaos_agent.preflight import LIST_CHECKS, check_blade, run_command
 
@@ -18,7 +18,7 @@ def _get_output_path() -> Path:
 
 
 def capabilities_sync(
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Sync skill capabilities: probe blade + LLM generate commands for each case.
 

--- a/blade-ai/src/chaos_agent/cli/commands/config.py
+++ b/blade-ai/src/chaos_agent/cli/commands/config.py
@@ -10,7 +10,7 @@ from chaos_agent.cli.config_manager import (
     LOCAL,
     SERVER,
 )
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 
 
 def _mask_value(key: str, value: object) -> object:
@@ -71,7 +71,7 @@ def config_command(
         None,
         help="Extra value (used when key=mode and value=server, this is the server URL)",
     ),
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Manage configuration: view and set all config values.
 

--- a/blade-ai/src/chaos_agent/cli/commands/confirm.py
+++ b/blade-ai/src/chaos_agent/cli/commands/confirm.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import typer
 
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 from chaos_agent.preflight import CONFIRM_CHECKS, run_command
 
 
@@ -12,7 +12,7 @@ def confirm_command(
     task_id: str = typer.Option(..., "--task-id", help="Task ID"),
     action: str = typer.Option(..., "--action", "-a", help="approve or reject"),
     reason: Optional[str] = typer.Option(None, "--reason", help="Reason"),
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Confirm or reject a pending task."""
 

--- a/blade-ai/src/chaos_agent/cli/commands/inject.py
+++ b/blade-ai/src/chaos_agent/cli/commands/inject.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import typer
 
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 from chaos_agent.config.settings import settings
 from chaos_agent.preflight import INJECT_CHECKS, run_command
 
@@ -27,7 +27,7 @@ def inject_command(
     context: Optional[str] = typer.Option(None, "--context", help="Kubeconfig context name"),
     force_override: bool = typer.Option(False, "--force-override", help="Force proceed when confirm_required (P1: same-action overlay)"),
     stream: bool = typer.Option(False, "--stream", help="Stream output in real-time (NL mode only)"),
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Inject a fault into a Kubernetes target.
 

--- a/blade-ai/src/chaos_agent/cli/commands/list_cmd.py
+++ b/blade-ai/src/chaos_agent/cli/commands/list_cmd.py
@@ -8,13 +8,13 @@ import json
 
 import typer
 
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 from chaos_agent.config.settings import settings
 from chaos_agent.skills.loader import get_skills_dir
 
 
 def list_command(
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """List supported fault capabilities (from last sync)."""
     primary = settings.resolved_memory_dir / "skill_capabilities.json"

--- a/blade-ai/src/chaos_agent/cli/commands/metric.py
+++ b/blade-ai/src/chaos_agent/cli/commands/metric.py
@@ -5,12 +5,12 @@ import asyncio
 import typer
 
 from chaos_agent.cli.config_manager import get_backend
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 
 
 def metric_command(
     task_id: str = typer.Option("", "--task-id", help="Task ID (omit to list all tasks)"),
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Query task status and execution metrics.
 

--- a/blade-ai/src/chaos_agent/cli/commands/recover.py
+++ b/blade-ai/src/chaos_agent/cli/commands/recover.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import typer
 
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 from chaos_agent.preflight import RECOVER_CHECKS, run_command
 
 
@@ -12,7 +12,7 @@ def recover_command(
     task_id: str = typer.Option(..., "--task-id", help="Task ID to recover"),
     target_name: Optional[str] = typer.Option(None, "--target-name", "-n", help="Specific target"),
     force: bool = typer.Option(False, "--force", help="Force recovery"),
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Recover a fault injection by task ID."""
 

--- a/blade-ai/src/chaos_agent/cli/commands/version.py
+++ b/blade-ai/src/chaos_agent/cli/commands/version.py
@@ -6,11 +6,11 @@ import typer
 
 from chaos_agent import __version__
 from chaos_agent.cli.config_manager import get_backend, get_mode
-from chaos_agent.cli.output import format_output
+from chaos_agent.cli.output import OutputFormat, format_output
 
 
 def version_command(
-    output: str = typer.Option("json", "--output", "-o", help="Output format: json|yaml"),
+    output: OutputFormat = typer.Option(OutputFormat.JSON, "--output", "-o", help="Output format: json|yaml"),
 ):
     """Show version information."""
     backend = get_backend()

--- a/blade-ai/src/chaos_agent/cli/output.py
+++ b/blade-ai/src/chaos_agent/cli/output.py
@@ -1,6 +1,7 @@
 """Output formatting: JSON/YAML output for CLI commands."""
 
 import json
+from enum import Enum
 
 try:
     import yaml
@@ -9,17 +10,45 @@ except ImportError:
     HAS_YAML = False
 
 
-def format_output(data: dict, output_format: str = "json") -> str:
+class OutputFormat(str, Enum):
+    """Supported CLI output formats.
+
+    Subclasses ``str`` so Typer renders/validates it as a plain choice and
+    the value compares equal to the corresponding string ("json"/"yaml").
+    """
+
+    JSON = "json"
+    YAML = "yaml"
+
+
+def format_output(data: dict, output_format: str = OutputFormat.JSON) -> str:
     """Format response data as JSON or YAML.
 
     Args:
         data: Response dict (the full envelope)
-        output_format: "json" or "yaml"
+        output_format: "json" or "yaml" (or an OutputFormat member)
 
     Returns:
         Formatted string
+
+    Raises:
+        ValueError: If output_format is not a supported format, or if "yaml"
+            is requested but PyYAML is not installed.
     """
-    if output_format == "yaml" and HAS_YAML:
+    try:
+        fmt = OutputFormat(output_format)
+    except ValueError:
+        supported = ", ".join(f.value for f in OutputFormat)
+        raise ValueError(
+            f"Unsupported output format: {output_format!r}. Supported formats: {supported}."
+        )
+
+    if fmt is OutputFormat.YAML:
+        if not HAS_YAML:
+            raise ValueError(
+                "YAML output requires PyYAML, which is not installed. "
+                "Install it with 'pip install pyyaml'."
+            )
         return yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False)
-    else:
-        return json.dumps(data, indent=2, ensure_ascii=False)
+
+    return json.dumps(data, indent=2, ensure_ascii=False)

--- a/blade-ai/tests/test_cli/test_output.py
+++ b/blade-ai/tests/test_cli/test_output.py
@@ -2,7 +2,10 @@
 
 import json
 
-from chaos_agent.cli.output import format_output
+import pytest
+
+from chaos_agent.cli import output as output_mod
+from chaos_agent.cli.output import OutputFormat, format_output
 
 
 class TestFormatOutput:
@@ -24,12 +27,19 @@ class TestFormatOutput:
         assert "\n" in result
 
     def test_yaml_format(self):
-        """yaml format should produce valid output (yaml if available, else json)."""
+        """yaml format should produce real YAML, not a JSON fallback."""
         data = {"code": 0, "message": "success"}
         result = format_output(data, "yaml")
-        # Either yaml or json - both should contain the key
-        assert "code" in result
-        assert "success" in result
+        # YAML renders "key: value"; the result is not valid JSON.
+        assert "code: 0" in result
+        assert "message: success" in result
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(result)
+
+    def test_yaml_via_enum_member(self):
+        """Passing the OutputFormat enum member works the same as the string."""
+        data = {"code": 0}
+        assert format_output(data, OutputFormat.YAML) == format_output(data, "yaml")
 
     def test_empty_dict(self):
         result = format_output({}, "json")
@@ -49,3 +59,24 @@ class TestFormatOutput:
         # Default should be json
         parsed = json.loads(result)
         assert parsed == data
+
+    def test_unknown_format_raises(self):
+        """An unrecognized format is rejected instead of silently returning JSON."""
+        with pytest.raises(ValueError, match="Unsupported output format"):
+            format_output({"key": "value"}, "xml")
+
+    def test_yaml_without_pyyaml_raises(self, monkeypatch):
+        """Requesting yaml without PyYAML installed raises a clear error."""
+        monkeypatch.setattr(output_mod, "HAS_YAML", False)
+        with pytest.raises(ValueError, match="PyYAML"):
+            format_output({"key": "value"}, "yaml")
+
+
+class TestOutputFormat:
+    def test_members(self):
+        assert OutputFormat.JSON.value == "json"
+        assert OutputFormat.YAML.value == "yaml"
+
+    def test_str_equality(self):
+        # str subclass: compares equal to its string value
+        assert OutputFormat.JSON == "json"


### PR DESCRIPTION
## Summary

Every blade-ai CLI command exposes `--output/-o` with help text `json|yaml`, but the value was an unvalidated `str` passed to `format_output()`. As a result any unrecognized format (e.g. a typo like `--output ymal`, or `--output xml`) **silently returned JSON** with no error or warning — and so did `--output yaml` when PyYAML was unavailable.

Fixes #1327

## Changes

- Add `OutputFormat(str, Enum)` in `cli/output.py` and type the `--output` option as that enum across all 8 commands (`config`, `capabilities_cmd`, `list_cmd`, `metric`, `confirm`, `inject`, `version`, `recover`), so **Typer rejects invalid values at the CLI boundary** and generates accurate help.
- `format_output()` now validates defensively: raises `ValueError` on an unknown format, and a clear "install pyyaml" `ValueError` when `yaml` is requested but PyYAML is missing (PyYAML is a declared dependency, so this only fires on a broken install).
- No change to valid `json`/`yaml` output; no new dependencies.

## Design notes

- `OutputFormat` subclasses `str`, so it compares equal to `"json"`/`"yaml"` — existing call sites that pass strings keep working unchanged.
- Hard error (not silent fallback) chosen deliberately: silently ignoring an invalid `--output` flag is a correctness problem for a CLI whose output is consumed by automation.

## Testing

Extended `tests/test_cli/test_output.py`: unknown format raises `ValueError`; `yaml` produces real YAML (not a JSON fallback); `yaml`-without-PyYAML raises a clear error; enum member and string paths are equivalent; default remains JSON. Logic verified locally.
